### PR TITLE
Rev/et 2137add pdssidebar and pdsheader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `DsSidebarMenuWidget`, sidebar navegable con estados `expanded/collapsed`, item activo, disabled, tooltip en modo colapsado, slots de header/footer y callback para toggle.
 - Test suite dedicada para `DsSidebarMenuWidget` cubriendo render, interacción, semántica de selección y toggle.
 - Showcase interactivo del sidebar en `example/lib/main.dart` y snippet de uso en el README.
+- Modelos de dominio DS adaptados a Pragma y exportados públicamente: `ModelThemeData`, `ModelSemanticColors`, `ModelDataVizPalette`, `ModelDsComponentAnatomy`, `ModelDesignSystem` y `ModelTypographyTokens`.
+- Integración de `ModelTypographyTokens` con `PragmaTypography` para construir `TextTheme` desde tokens (`textThemeFromTokens`).
+- Extensiones de tema para consumir DS desde `ThemeData`: `DsExtendedTokensExtension`, `DsSemanticColorsExtension` y `DsDataVizPaletteExtension`.
+- Pruebas de roundtrip/serialización y construcción de tema para el agregado `ModelDesignSystem` y los nuevos modelos de dominio.
 
 ## [1.4.0] - 2025-12-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `DsHeaderWidget`, header base con label a la izquierda y área de acciones flexibles a la derecha, con comportamiento responsivo para anchos compactos.
 - `DsSidebarMenuWidget`, sidebar navegable con estados `expanded/collapsed`, item activo, disabled, tooltip en modo colapsado, slots de header/footer y callback para toggle.
 - Test suite dedicada para `DsSidebarMenuWidget` cubriendo render, interacción, semántica de selección y toggle.
 - Showcase interactivo del sidebar en `example/lib/main.dart` y snippet de uso en el README.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.5.0] - 2026-02-16
 
 ### Added
 
@@ -17,6 +17,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Integración de `ModelTypographyTokens` con `PragmaTypography` para construir `TextTheme` desde tokens (`textThemeFromTokens`).
 - Extensiones de tema para consumir DS desde `ThemeData`: `DsExtendedTokensExtension`, `DsSemanticColorsExtension` y `DsDataVizPaletteExtension`.
 - Pruebas de roundtrip/serialización y construcción de tema para el agregado `ModelDesignSystem` y los nuevos modelos de dominio.
+- Documentación nueva para DS: `doc/ds_sidebar.md`, `doc/ds_header.md`, `doc/ds_models.md` y `doc/model_ds_sidebar_menu_item.md`.
+
+### Changed
+
+- `example/lib/main.dart` reorganizado con layout principal `DsSidebarMenuWidget + DsHeaderWidget`, índice lateral por secciones y navegación por anclas.
+- `README.md` actualizado con flujo de integración `Sidebar -> Model -> Widget -> Layout -> AppManager` y referencias a la nueva documentación.
+
+### Fixed
+
+- Ajuste de contraste del label en `DsSidebarMenuWidget` para usar el mismo color base de foreground que los íconos.
+- Correcciones de overflow en header del sidebar en anchos reducidos y consistencia de scroll hacia secciones en el example.
 
 ## [1.4.0] - 2025-12-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `DsSidebarMenuWidget`, sidebar navegable con estados `expanded/collapsed`, item activo, disabled, tooltip en modo colapsado, slots de header/footer y callback para toggle.
+- Test suite dedicada para `DsSidebarMenuWidget` cubriendo render, interacción, semántica de selección y toggle.
+- Showcase interactivo del sidebar en `example/lib/main.dart` y snippet de uso en el README.
+
 ## [1.4.0] - 2025-12-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Flutter library focused on mobile experiences that bundles Pragma's design token
 - Radio pills (`PragmaRadioButtonWidget`) with neon stroke, optional helper text, hover/pressed glow, and disabled styling.
 - Glow checkboxes (`PragmaCheckboxWidget`) with multi-select support, indeterminate state, dense mode, and hover/pressed neon outline.
 - Sidebar navigation (`DsSidebarMenuWidget`) with expanded/collapsed states, active item highlighting, disabled rows, and tooltip labels while collapsed.
+- Header scaffold (`DsHeaderWidget`) with left title, flexible right-side actions, and compact behavior for narrow layouts.
 - Status badges (`PragmaBadgeWidget`) with light/dark palettes, icon slot, tone presets, and compact padding.
 - Accessible components (`PragmaButton`, `PragmaCard`, `PragmaIconButtonWidget`, `PragmaInputWidget`, `PragmaToastWidget`, `PragmaAccordionWidget`, `PragmaColorTokenRowWidget`, `PragmaThemeEditorWidget`, `PragmaLogoWidget`).
 - Theme lab sample that lets you edit colors/typography in real time and export a JSON payload backed by `ModelThemePragma`.
@@ -133,6 +134,25 @@ DsSidebarMenuWidget(
 	collapsed: false,
 	onItemTap: (String id) {},
 	onCollapsedToggle: (bool collapsed) {},
+)
+```
+
+### Header quick sample
+
+```dart
+DsHeaderWidget(
+	title: 'Area de trabajo',
+	actions: <Widget>[
+		IconButton(
+			tooltip: 'Buscar',
+			onPressed: () {},
+			icon: const Icon(Icons.search),
+		),
+		const PragmaAvatarWidget(
+			radius: PragmaSpacing.sm,
+			initials: 'PD',
+		),
+	],
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Flutter library focused on mobile experiences that bundles Pragma's design token
 - Neon tags (`PragmaTagWidget`) with gradient capsules, avatar slot, hover/pressed glow, and removable actions.
 - Radio pills (`PragmaRadioButtonWidget`) with neon stroke, optional helper text, hover/pressed glow, and disabled styling.
 - Glow checkboxes (`PragmaCheckboxWidget`) with multi-select support, indeterminate state, dense mode, and hover/pressed neon outline.
+- Sidebar navigation (`DsSidebarMenuWidget`) with expanded/collapsed states, active item highlighting, disabled rows, and tooltip labels while collapsed.
 - Status badges (`PragmaBadgeWidget`) with light/dark palettes, icon slot, tone presets, and compact padding.
 - Accessible components (`PragmaButton`, `PragmaCard`, `PragmaIconButtonWidget`, `PragmaInputWidget`, `PragmaToastWidget`, `PragmaAccordionWidget`, `PragmaColorTokenRowWidget`, `PragmaThemeEditorWidget`, `PragmaLogoWidget`).
 - Theme lab sample that lets you edit colors/typography in real time and export a JSON payload backed by `ModelThemePragma`.
@@ -106,6 +107,32 @@ PragmaButton.icon(
 	icon: Icons.open_in_new,
 	hierarchy: PragmaButtonHierarchy.tertiary,
 	onPressed: () {},
+)
+```
+
+### Sidebar quick sample
+
+```dart
+final List<ModelDsSidebarMenuItem> items = <ModelDsSidebarMenuItem>[
+	ModelDsSidebarMenuItem(
+		id: 'dashboard',
+		label: 'Dashboard',
+		iconToken: DsSidebarIconToken.dashboard,
+	),
+	ModelDsSidebarMenuItem(
+		id: 'reports',
+		label: 'Reportes',
+		iconToken: DsSidebarIconToken.reports,
+	),
+];
+
+DsSidebarMenuWidget(
+	title: 'Creci',
+	items: items,
+	activeId: 'dashboard',
+	collapsed: false,
+	onItemTap: (String id) {},
+	onCollapsedToggle: (bool collapsed) {},
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Flutter library focused on mobile experiences that bundles Pragma's design token
 - Glow checkboxes (`PragmaCheckboxWidget`) with multi-select support, indeterminate state, dense mode, and hover/pressed neon outline.
 - Sidebar navigation (`DsSidebarMenuWidget`) with expanded/collapsed states, active item highlighting, disabled rows, and tooltip labels while collapsed.
 - Header scaffold (`DsHeaderWidget`) with left title, flexible right-side actions, and compact behavior for narrow layouts.
+- Domain-ready DS models: `ModelDesignSystem`, `ModelThemeData`, `ModelSemanticColors`, `ModelDataVizPalette`, `DsExtendedTokens`, `ModelTypographyTokens`, and `ModelDsComponentAnatomy`.
 - Status badges (`PragmaBadgeWidget`) with light/dark palettes, icon slot, tone presets, and compact padding.
 - Accessible components (`PragmaButton`, `PragmaCard`, `PragmaIconButtonWidget`, `PragmaInputWidget`, `PragmaToastWidget`, `PragmaAccordionWidget`, `PragmaColorTokenRowWidget`, `PragmaThemeEditorWidget`, `PragmaLogoWidget`).
 - Theme lab sample that lets you edit colors/typography in real time and export a JSON payload backed by `ModelThemePragma`.
@@ -64,7 +65,7 @@ class PragmaApp extends StatelessWidget {
 ## Tokens and components
 
 - **Colors:** `PragmaColors` exposes brand-aware `ColorScheme` definitions for light and dark modes.
-- **Typography:** `PragmaTypography` defines responsive scales built on top of Google Fonts.
+- **Typography:** `PragmaTypography` defines responsive scales built on top of Google Fonts and can build `TextTheme` from `ModelTypographyTokens`.
 - **Spacing:** `PragmaSpacing` concentrates 4pt-system values and handy utilities.
 - **Radius:** `PragmaBorderRadiusTokens` and `PragmaBorderRadius` keep rounded corners consistent in 4/8dp steps.
 - Rounded-corner guidance lives in [doc/rounded_corners.md](doc/rounded_corners.md), covering increments, implementation, and heuristics per component size.
@@ -78,7 +79,7 @@ class PragmaApp extends StatelessWidget {
 - Pagination guidance vive en [doc/pagination.md](doc/pagination.md), documentando cápsula, gaps, summary y selector por página.
 - Badge guidance vive en [doc/badge.md](doc/badge.md), detallando tonos light/dark, anatomía y casos de uso informativos.
 - **Opacity:** `PragmaOpacityTokens` and `PragmaOpacity` constrain overlays to 8/30/60 intervals using `Color.withValues` for Flutter 3.22+.
-- **Domain models:** `ModelPragmaComponent`, `ModelAnatomyAttribute`, `ModelFieldState`, `ModelColorToken`, and `ModelThemePragma` serialize the documentation sourced from Figma, power the input widgets, and guarantee JSON roundtrips.
+- **Domain models:** `ModelDesignSystem`, `ModelThemeData`, `ModelSemanticColors`, `ModelDataVizPalette`, `DsExtendedTokens`, `ModelTypographyTokens`, `ModelDsComponentAnatomy`, `ModelPragmaComponent`, `ModelAnatomyAttribute`, `ModelFieldState`, `ModelColorToken`, and `ModelThemePragma` serialize documentation and theme contracts with JSON roundtrip support.
 - **Grid:** `PragmaGridTokens`, `getGridConfigFromContext`, `PragmaGridContainer`, and `PragmaScaleBox` help replicate the official grid, respect gutters, and scale full mockups.
 - **Components:** Widgets such as `PragmaPrimaryButton`, `PragmaSecondaryButton`, `PragmaButton.icon`, `PragmaCard`, `PragmaCardWidget`, `PragmaDropdownWidget`, `PragmaInputWidget`, `PragmaToastWidget`, `PragmaAvatarWidget`, `PragmaBreadcrumbWidget`, `PragmaAccordionWidget`, `PragmaColorTokenRowWidget`, `PragmaThemeEditorWidget`, `PragmaLogoWidget`, `PragmaCalendarWidget`, `PragmaLoadingWidget`, or `PragmaTableWidget` ship consistent states and elevation.
 
@@ -154,6 +155,24 @@ DsHeaderWidget(
 		),
 	],
 )
+```
+
+### Design system model sample
+
+```dart
+final ModelDesignSystem designSystem = ModelDesignSystem.pragmaDefault();
+
+final ThemeData lightTheme = designSystem.toThemeData(
+	brightness: Brightness.light,
+);
+
+final ModelDesignSystem tuned = designSystem.copyWith(
+	typographyTokens: designSystem.typographyTokens.copyWith(
+		bodyMedium: designSystem.typographyTokens.bodyMedium.copyWith(
+			fontSize: 18,
+		),
+	),
+);
 ```
 
 ### Icon button quick sample

--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ class PragmaApp extends StatelessWidget {
 - Tooltip guidance vive en [doc/tooltip.md](doc/tooltip.md), detallando anatomía light/dark, delays, arrow placements y patrones touch.
 - Pagination guidance vive en [doc/pagination.md](doc/pagination.md), documentando cápsula, gaps, summary y selector por página.
 - Badge guidance vive en [doc/badge.md](doc/badge.md), detallando tonos light/dark, anatomía y casos de uso informativos.
+- Sidebar guidance vive en [doc/ds_sidebar.md](doc/ds_sidebar.md), documentando anatomía, estados expanded/collapsed y contrato del modelo de items.
+- Sidebar item model vive en [doc/model_ds_sidebar_menu_item.md](doc/model_ds_sidebar_menu_item.md), con contrato de `ModelDsSidebarMenuItem` e icon tokens permitidos.
+- Header guidance vive en [doc/ds_header.md](doc/ds_header.md), con layout base, acciones composables y recomendaciones responsive.
+- DS models guidance vive en [doc/ds_models.md](doc/ds_models.md), consolidando los modelos de dominio del sistema de diseño.
 - **Opacity:** `PragmaOpacityTokens` and `PragmaOpacity` constrain overlays to 8/30/60 intervals using `Color.withValues` for Flutter 3.22+.
 - **Domain models:** `ModelDesignSystem`, `ModelThemeData`, `ModelSemanticColors`, `ModelDataVizPalette`, `DsExtendedTokens`, `ModelTypographyTokens`, `ModelDsComponentAnatomy`, `ModelPragmaComponent`, `ModelAnatomyAttribute`, `ModelFieldState`, `ModelColorToken`, and `ModelThemePragma` serialize documentation and theme contracts with JSON roundtrip support.
 - **Grid:** `PragmaGridTokens`, `getGridConfigFromContext`, `PragmaGridContainer`, and `PragmaScaleBox` help replicate the official grid, respect gutters, and scale full mockups.
@@ -173,6 +177,33 @@ final ModelDesignSystem tuned = designSystem.copyWith(
 		),
 	),
 );
+```
+
+### Sidebar integration flow (AppManager -> Model -> Widget -> Layout)
+
+Use this sequence to keep navigation predictable and controlled:
+
+1. **AppManager/state** defines `collapsed`, `activeId`, permissions, and feature flags.
+2. **Model** builds `List<ModelDsSidebarMenuItem>` as the final navigation contract.
+3. **Widget** renders `DsSidebarMenuWidget` as a controlled component (no internal state mutation).
+4. **Layout** composes `Sidebar + Header + WorkArea` and reacts to `collapsed/activeId`.
+5. **AppManager/state** receives callbacks (`onItemTap`, `onCollapsedToggle`) and updates state/router.
+
+```dart
+class AppState {
+  final bool collapsed;
+  final String activeId;
+  final List<ModelDsSidebarMenuItem> items;
+  // ...
+}
+
+DsSidebarMenuWidget(
+  items: state.items,
+  activeId: state.activeId,
+  collapsed: state.collapsed,
+  onItemTap: (String id) => appManager.selectSection(id),
+  onCollapsedToggle: (bool value) => appManager.setCollapsed(value),
+)
 ```
 
 ### Icon button quick sample

--- a/doc/ds_header.md
+++ b/doc/ds_header.md
@@ -1,0 +1,138 @@
+# DsHeaderWidget
+
+`DsHeaderWidget` define la franja superior de contexto para páginas internas del sistema. Presenta un título principal a la izquierda y un área de acciones composables a la derecha, manteniendo coherencia visual y responsividad.
+
+---
+
+## Objetivo
+
+- Estandarizar encabezados de pantallas tipo workspace.
+- Permitir acciones heterogéneas (botones, avatar, chips, toggles, superficies informativas).
+- Mantener una composición estable en desktop y compacta en anchos reducidos.
+- Evitar que cada equipo implemente su propio header ad-hoc.
+
+---
+
+## Naturaleza del widget
+
+`DsHeaderWidget` es un widget declarativo y sin estado interno.
+
+- No administra lógica de negocio.
+- No gestiona navegación.
+- No controla el estado del sidebar.
+- Toda su variación visual depende de sus props y del layout disponible.
+
+---
+
+## Anatomía
+
+1. **Título principal** (lado izquierdo).
+2. **Área de acciones** (lado derecho, disposición horizontal).
+3. **Superficies auxiliares opcionales** mediante `DsHeaderActionSurface`.
+
+---
+
+## Props principales
+
+- `title` (`String`)
+  Texto principal del encabezado.
+
+- `actions` (`List<Widget>`)
+  Conjunto de widgets que se renderizan en el lado derecho.
+
+- `compactBreakpoint` (`double`, default recomendado: `960`)
+  Ancho en logical pixels a partir del cual el header cambia a modo compacto.
+
+- `padding` (`EdgeInsetsGeometry`)
+  Espaciado interno del header.
+
+---
+
+## Composición de acciones
+
+Se recomienda la siguiente jerarquía visual:
+
+- **Acciones primarias:** `IconButton` o `TextButton.icon`.
+- **Identidad / usuario:** `PragmaAvatarWidget`.
+- **Bloques informativos o contextuales:** `DsHeaderActionSurface`.
+- **Acciones destructivas:** deben explicitar semántica y tooltip.
+
+Evitar:
+
+- Acciones puramente icónicas sin `tooltip`.
+- Lógica de negocio directamente dentro de callbacks complejos.
+
+---
+
+## Responsividad
+
+### En ancho amplio
+
+- Distribución horizontal estable.
+- Título alineado a la izquierda.
+- Acciones visibles en línea.
+- Sin wrapping salvo overflow explícito.
+
+### En ancho compacto
+
+- Se prioriza la legibilidad del título.
+- El título puede aplicar `ellipsis` si es necesario.
+- Las acciones pueden usar `Wrap` o ajuste dinámico para evitar overflow.
+- El padding puede reducirse según constraints.
+
+---
+
+## Accesibilidad
+
+- Utiliza controles nativos (`IconButton`, `TextButton`) para soporte de foco y teclado.
+- Define `tooltip` o labels descriptivos en iconografía.
+- Evita acciones sin nombre semántico.
+- Mantén contraste adecuado según el tema activo.
+
+---
+
+## Integración arquitectónica
+
+- Debe utilizarse exclusivamente en la capa **UI**.
+- No debe recibir entidades de dominio directamente.
+- Transformaciones o mapeos deben realizarse en Presenter / ViewModel.
+- No debe contener lógica condicional basada en roles o ACL.
+
+---
+
+## No hace
+
+- No implementa navegación.
+- No gestiona scroll.
+- No aplica elevación dinámica.
+- No controla el estado del sidebar.
+- No administra permisos.
+
+---
+
+## Ejemplo
+
+```dart
+DsHeaderWidget(
+  title: 'Área de trabajo',
+  actions: <Widget>[
+    DsHeaderActionSurface(
+      child: const Text('Ambiente: demo'),
+    ),
+    IconButton(
+      tooltip: 'Buscar',
+      onPressed: () {},
+      icon: const Icon(Icons.search),
+    ),
+    TextButton.icon(
+      onPressed: () {},
+      icon: const Icon(Icons.keyboard_double_arrow_left),
+      label: const Text('Contraer'),
+    ),
+    const PragmaAvatarWidget(
+      radius: PragmaSpacing.sm,
+      initials: 'PD',
+    ),
+  ],
+)
+```

--- a/doc/ds_models.md
+++ b/doc/ds_models.md
@@ -1,0 +1,207 @@
+# DS Models
+
+Este documento centraliza los modelos de dominio del Design System incluidos en la librería `pragma_design_system`.
+
+## Objetivo
+
+- Definir contratos serializables para tokens, tema y metadatos de componentes.
+- Separar la representación del DS de la lógica de negocio de cada app consumidora.
+- Garantizar roundtrip JSON (`toJson` / `fromJson`) como base de interoperabilidad.
+
+## Principios de modelado
+
+- Los modelos son inmutables.
+- Los modelos son serializables.
+- Los modelos no contienen lógica de negocio de aplicación.
+- Los modelos no ejecutan side-effects.
+- Los modelos base priorizan desacoplamiento de widgets cuando es posible.
+
+## Estabilidad del contrato
+
+- Cambios de estructura en modelos o keys JSON pueden ser breaking changes.
+- Los payloads JSON deben versionarse cuando cambien forma o significado.
+- Se recomienda mantener compatibilidad hacia atrás en `fromJson` cuando sea viable.
+
+## Dependencia con Flutter
+
+- Algunos modelos actúan como adaptadores hacia `ThemeData` (`ModelDesignSystem`, `ModelThemeData`).
+- Otros modelos son contratos de tokens y datos de dominio (`DsExtendedTokens`, `ModelTypographyTokens`, `ModelSemanticColors`, `ModelDataVizPalette`, `ModelDsComponentAnatomy`, `ModelDsSidebarMenuItem`).
+- La capa visual (`widgets`) consume estos modelos; no al revés.
+
+## No hace
+
+- No gestiona estado de aplicación (auth, ACL, router).
+- No implementa navegación de app.
+- No define layout final de pantallas.
+- No reemplaza componentes visuales.
+- No contiene reglas de negocio de cada módulo consumidor.
+
+## Modelos principales
+
+## `ModelDesignSystem`
+
+Agregado raíz del DS y punto único de composición del sistema de diseño.
+
+Incluye:
+- `theme` (`ModelThemeData`)
+- `tokens` (`DsExtendedTokens`)
+- `semanticLight` / `semanticDark` (`ModelSemanticColors`)
+- `dataViz` (`ModelDataVizPalette`)
+- `typographyTokens` (`ModelTypographyTokens`)
+
+Métodos clave:
+- `ModelDesignSystem.pragmaDefault()`
+- `toJson()` / `fromJson()`
+- `toThemeData(brightness: ...)`
+- `copyWith(...)`
+
+Diagrama mental:
+
+```text
+ModelDesignSystem
+ ├── ModelThemeData
+ ├── DsExtendedTokens
+ ├── ModelTypographyTokens
+ ├── ModelSemanticColors (light/dark)
+ ├── ModelDataVizPalette
+ └── ModelDsComponentAnatomy
+```
+
+## `ModelThemeData`
+
+Modelo de tema base para light/dark.
+
+Incluye:
+- `lightScheme`, `darkScheme` (`ColorScheme`)
+- `lightTextTheme`, `darkTextTheme` (`TextTheme`)
+- `useMaterial3`
+
+Métodos:
+- `ModelThemeData.pragmaDefault()`
+- `fromThemeData(...)`
+- `toThemeData(...)`
+- `toJson()` / `fromJson()`
+
+## `DsExtendedTokens`
+
+Escalas de tokens extendidos del DS:
+- spacing (`xs`..`xxl`)
+- border radius (`xs`..`xxl`)
+- elevation (`xs`..`xxl`)
+- alpha (`withAlpha*`)
+- durations de animación
+
+Métodos:
+- `const DsExtendedTokens()`
+- `DsExtendedTokens.fromFactor(...)`
+- `toJson()` / `fromJson()`
+
+## `ModelTypographyTokens`
+
+Modelo tipográfico de dominio desacoplado de Flutter UI.
+
+Incluye 15 slots compatibles con `TextTheme`:
+- `displayLarge`, `displayMedium`, `displaySmall`
+- `headlineLarge`, `headlineMedium`, `headlineSmall`
+- `titleLarge`, `titleMedium`, `titleSmall`
+- `bodyLarge`, `bodyMedium`, `bodySmall`
+- `labelLarge`, `labelMedium`, `labelSmall`
+
+Cada slot usa `ModelTypographyTokenStyle` con:
+- `fontSize`
+- `lineHeight`
+- `fontWeight`
+- `letterSpacing` (opcional)
+
+Relación con `PragmaTypography`:
+- `PragmaTypography.textThemeFromTokens(...)` transforma este modelo en `TextTheme`.
+
+## `ModelSemanticColors`
+
+Paletas semánticas para estados de dominio:
+- success
+- warning
+- info
+
+Incluye pares `color / onColor` y `container / onContainer` para light y dark.
+
+Métodos:
+- `fallbackLight()`
+- `fallbackDark()`
+- `fromColorScheme(...)`
+- `toJson()` / `fromJson()`
+
+## `ModelDataVizPalette`
+
+Modelo para visualización de datos:
+- `categorical` (series discretas)
+- `sequential` (escala continua)
+
+Métodos:
+- `fallback()`
+- `categoricalAt(int)`
+- `sequentialAt(double)`
+- `toJson()` / `fromJson()`
+
+## `ModelDsComponentAnatomy`
+
+Metamodelo para documentar anatomía de componentes del DS.
+
+Incluye:
+- metadatos (`id`, `name`, `description`, `status`, `platforms`)
+- tags
+- links
+- slots anatómicos (`ModelDsComponentSlot`)
+
+## `ModelDsSidebarMenuItem`
+
+Modelo de entrada de navegación para `DsSidebarMenuWidget`.
+
+Incluye:
+- `id`
+- `label`
+- `iconToken`
+- `enabled`
+- `semanticLabel` opcional
+
+Detalle completo del modelo:
+- [model_ds_sidebar_menu_item.md](model_ds_sidebar_menu_item.md)
+
+## Extensiones de tema
+
+Para recuperar modelos del DS desde `ThemeData`:
+- `DsExtendedTokensExtension`
+- `DsSemanticColorsExtension`
+- `DsDataVizPaletteExtension`
+
+Helper extension:
+- `theme.dsTokens`
+- `theme.dsSemantic`
+- `theme.dsDataViz`
+
+## Ejemplo de uso integral
+
+```dart
+final ModelDesignSystem ds = ModelDesignSystem.pragmaDefault();
+
+final ThemeData light = ds.toThemeData(
+  brightness: Brightness.light,
+);
+
+final ModelDesignSystem tuned = ds.copyWith(
+  typographyTokens: ds.typographyTokens.copyWith(
+    bodyMedium: ds.typographyTokens.bodyMedium.copyWith(fontSize: 18),
+  ),
+);
+
+final Map<String, dynamic> payload = tuned.toJson();
+final ModelDesignSystem restored = ModelDesignSystem.fromJson(payload);
+
+assert(restored == tuned);
+```
+
+## Recomendaciones para apps consumidoras
+
+1. Mantén reglas de negocio fuera de widgets DS y opera sobre estos modelos antes de renderizar.
+2. Versiona payloads JSON en backend/config para trazabilidad de cambios de diseño.
+3. Reutiliza `ModelDesignSystem` como punto único de composición para evitar divergencias entre módulos.

--- a/doc/ds_sidebar.md
+++ b/doc/ds_sidebar.md
@@ -1,0 +1,193 @@
+# DsSidebarMenuWidget
+
+`DsSidebarMenuWidget` representa el menú lateral de navegación del sistema.
+Está diseñado como un componente completamente controlado, predecible y desacoplado de estado interno.
+
+---
+
+## Naturaleza del componente
+
+### Controlled Component
+
+- Es **completamente controlado**.
+- Implementado como `StatelessWidget`.
+- **No muta internamente**:
+  - `collapsed`
+  - `activeId`
+
+- Renderiza exclusivamente según props.
+- Emite eventos vía callbacks.
+
+Este diseño garantiza:
+
+- Previsibilidad.
+- Testeo simple.
+- Integración limpia con ViewModel / Bloc / Notifier externo.
+
+---
+
+## Estado de colapsado
+
+El estado siempre es externo.
+
+### Escenario 1 — Toggle interno
+
+Si:
+
+```dart
+showCollapseToggle = true
+```
+
+Se renderiza un botón interno en el header que ejecuta:
+
+```dart
+onCollapsedToggle(!collapsed)
+```
+
+El widget **no cambia estado por sí mismo**.
+
+---
+
+### Escenario 2 — Control externo
+
+Si:
+
+```dart
+showCollapseToggle = false
+```
+
+El layout padre puede manejar el colapsado desde:
+
+- Header global
+- Botón externo
+- Shortcut de teclado
+- Layout responsivo
+
+El componente solo refleja el valor recibido en `collapsed`.
+
+---
+
+## Scroll behavior
+
+La lista de items usa:
+
+```dart
+ListView.separated
+```
+
+### Layout con alto acotado (`constraints.hasBoundedHeight == true`)
+
+Estructura:
+
+```
+Column
+ ├─ Header
+ ├─ Expanded(ListView)
+ └─ Footer (opcional)
+```
+
+- El header queda fijo arriba.
+- El footer queda fijo abajo.
+- Solo la lista scrollea.
+
+---
+
+### Layout no acotado
+
+- `ListView` pasa a `shrinkWrap: true`
+- `physics: NeverScrollableScrollPhysics`
+- El scroll lo gestiona el contenedor padre.
+
+Esto evita conflictos de scroll anidado.
+
+---
+
+## Modelo de navegación
+
+Actualmente soporta:
+
+```dart
+List<ModelDsSidebarMenuItem>
+```
+
+Referencia detallada del modelo:
+- [model_ds_sidebar_menu_item.md](model_ds_sidebar_menu_item.md)
+
+### Tipo de navegación
+
+- ✔ Lista plana
+- ❌ No soporta:
+  - Secciones
+  - Agrupaciones
+  - Submenús
+  - Árbol jerárquico
+  - Expansión por niveles
+
+Debe considerarse explícitamente como:
+
+> **Flat navigation only**
+
+Si en el futuro se requiere jerarquía, deberá diseñarse otro componente o extender el modelo.
+
+---
+
+## Resolución de ancho
+
+Props disponibles:
+
+- `width` (default: `224`)
+- `collapsedWidth` (default: `72`)
+
+Ambos son configurables.
+
+El header interno también adapta su layout para evitar overflow cuando el ancho es reducido.
+
+---
+
+## Iconografía
+
+- `iconToken` es de tipo `DsSidebarIconToken` (enum).
+- Se resuelve internamente mediante `_SidebarIconResolver`.
+- Actualmente usa iconografía Material (`Icons.*`).
+- No soporta SVG nativamente.
+
+Si se migra a SVG o Design Tokens de íconos, deberá reemplazarse el resolver.
+
+---
+
+## Comportamiento cuando `activeId` no existe
+
+Si el `activeId` recibido:
+
+- No coincide con ningún item
+
+El comportamiento es:
+
+- No se marca ningún item como activo.
+- No se lanza assert.
+- No hay fallback automático al primer item.
+
+Esto forma parte del contrato actual del componente.
+
+---
+
+## No hace
+
+- No maneja rutas.
+- No ejecuta navegación.
+- No controla permisos.
+- No sincroniza estado con URL.
+- No persiste colapsado.
+- No soporta jerarquía.
+
+---
+
+# Evaluación rápida
+
+Esto ya está a nivel:
+
+✔ Componente enterprise
+✔ Predecible
+✔ Testeable
+✔ Clean Architecture friendly
+✔ Compatible con tu filosofía de controlled widgets

--- a/doc/model_ds_sidebar_menu_item.md
+++ b/doc/model_ds_sidebar_menu_item.md
@@ -1,0 +1,153 @@
+# ModelDsSidebarMenuItem (versión refinada)
+
+---
+
+# ModelDsSidebarMenuItem
+
+`ModelDsSidebarMenuItem` es el modelo de dominio que representa una entrada de navegación consumida por `DsSidebarMenuWidget`.
+
+Define el contrato mínimo necesario para renderizar navegación lateral sin acoplar lógica de negocio al widget visual.
+
+---
+
+## Objetivo
+
+- Definir un contrato **inmutable, tipado y serializable**.
+- Separar reglas de negocio (qué items mostrar, habilitar o activar) del componente visual.
+- Permitir interoperabilidad mediante JSON roundtrip.
+- Garantizar igualdad estructural para comparaciones y tests.
+
+---
+
+## Naturaleza del modelo
+
+- Es un **modelo puro de dominio**.
+- No contiene lógica de navegación.
+- No conoce rutas ni contexto UI.
+- No depende de Flutter.
+
+Esto permite:
+
+- Test unitarios sin dependencia de UI.
+- Persistencia o sincronización remota.
+- Versionamiento estable del contrato.
+
+---
+
+## Estructura
+
+- `id` (`String`)
+  Identificador estable y único dentro del sidebar.
+
+- `label` (`String`)
+  Texto visible en modo expandido y usado como tooltip en modo colapsado.
+
+- `iconToken` (`DsSidebarIconToken`)
+  Token tipado que representa el ícono permitido por el Design System.
+
+- `enabled` (`bool`)
+  Define si el item es interactivo.
+
+- `semanticLabel` (`String?`)
+  Etiqueta opcional para accesibilidad. Si es `null`, puede derivarse de `label`.
+
+---
+
+## Icon tokens permitidos
+
+Enum `DsSidebarIconToken` actualmente soporta:
+
+- `dashboard`
+- `projects`
+- `reports`
+- `settings`
+- `back`
+- `home`
+- `analytics`
+- `lock`
+
+El conjunto de tokens es cerrado y controlado por el Design System.
+
+---
+
+## Comportamiento contractual
+
+1. El modelo es completamente inmutable.
+2. Implementa `toJson()` y `fromJson()`.
+3. Implementa `copyWith()` para derivar variantes.
+4. Si `fromJson(null)` es invocado, retorna `ModelDsSidebarMenuItem.empty`.
+5. Si `iconToken` no coincide con un valor conocido, usa fallback `home`.
+6. Dos instancias con mismas propiedades deben ser consideradas iguales (`==` y `hashCode` coherentes).
+
+---
+
+## Consideraciones importantes
+
+### Identidad
+
+- `id` debe ser estable.
+- No debe derivarse de texto visible.
+- No debe cambiar entre versiones si representa la misma funcionalidad.
+
+### Validación
+
+El modelo no valida permisos ni reglas de acceso.
+Es responsabilidad de la capa de dominio o estado:
+
+- Filtrar items.
+- Marcar `enabled`.
+- Determinar `activeId`.
+
+---
+
+## No hace
+
+- No define rutas.
+- No conoce navegación.
+- No maneja jerarquías.
+- No contiene estado UI.
+- No resuelve iconos (eso es responsabilidad del widget).
+
+---
+
+## Ejemplo
+
+```dart
+final ModelDsSidebarMenuItem item = ModelDsSidebarMenuItem(
+  id: 'reports',
+  label: 'Reportes',
+  iconToken: DsSidebarIconToken.reports,
+  enabled: true,
+  semanticLabel: 'Ir a reportes',
+);
+
+final Map<String, dynamic> json = item.toJson();
+final ModelDsSidebarMenuItem restored = ModelDsSidebarMenuItem.fromJson(json);
+
+assert(item == restored);
+```
+
+---
+
+## Uso recomendado en apps
+
+1. Mantener la lista de items en la capa de estado o dominio.
+2. Resolver reglas de negocio (roles, ACL, feature flags) antes de renderizar.
+3. Pasar al widget únicamente:
+   - Lista final filtrada.
+   - `activeId`.
+   - `collapsed`.
+
+4. Evitar lógica condicional dentro del widget.
+
+---
+
+# Evaluación honesta
+
+Esto ya está en nivel:
+
+✔ Dominio bien definido
+✔ Compatible con Clean Architecture
+✔ Compatible con JSON schema
+✔ Test-friendly
+✔ Evolutivo

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -45,7 +45,7 @@ class _PragmaShowcaseAppState extends State<PragmaShowcaseApp> {
   }
 }
 
-class ShowcaseScreen extends StatelessWidget {
+class ShowcaseScreen extends StatefulWidget {
   const ShowcaseScreen({
     required this.mode,
     required this.onModeChanged,
@@ -54,6 +54,98 @@ class ShowcaseScreen extends StatelessWidget {
 
   final ThemeMode mode;
   final ValueChanged<bool> onModeChanged;
+
+  @override
+  State<ShowcaseScreen> createState() => _ShowcaseScreenState();
+}
+
+class _ShowcaseScreenState extends State<ShowcaseScreen> {
+  bool _sidebarCollapsed = false;
+  String _activeSidebarId = 'overview';
+
+  final Map<String, GlobalKey> _sectionKeys = <String, GlobalKey>{
+    'overview': GlobalKey(),
+    'tokens': GlobalKey(),
+    'base': GlobalKey(),
+    'navigation': GlobalKey(),
+    'forms': GlobalKey(),
+    'feedback': GlobalKey(),
+    'data': GlobalKey(),
+    'overlays': GlobalKey(),
+    'docs': GlobalKey(),
+  };
+
+  static final List<ModelDsSidebarMenuItem> _sidebarItems =
+      <ModelDsSidebarMenuItem>[
+    ModelDsSidebarMenuItem(
+      id: 'overview',
+      label: 'Inicio',
+      iconToken: DsSidebarIconToken.home,
+    ),
+    ModelDsSidebarMenuItem(
+      id: 'tokens',
+      label: 'Tokens',
+      iconToken: DsSidebarIconToken.analytics,
+    ),
+    ModelDsSidebarMenuItem(
+      id: 'base',
+      label: 'Base',
+      iconToken: DsSidebarIconToken.dashboard,
+    ),
+    ModelDsSidebarMenuItem(
+      id: 'navigation',
+      label: 'Navegacion',
+      iconToken: DsSidebarIconToken.projects,
+    ),
+    ModelDsSidebarMenuItem(
+      id: 'forms',
+      label: 'Formularios',
+      iconToken: DsSidebarIconToken.lock,
+    ),
+    ModelDsSidebarMenuItem(
+      id: 'feedback',
+      label: 'Feedback',
+      iconToken: DsSidebarIconToken.settings,
+    ),
+    ModelDsSidebarMenuItem(
+      id: 'data',
+      label: 'Datos',
+      iconToken: DsSidebarIconToken.reports,
+    ),
+    ModelDsSidebarMenuItem(
+      id: 'overlays',
+      label: 'Overlays',
+      iconToken: DsSidebarIconToken.analytics,
+    ),
+    ModelDsSidebarMenuItem(
+      id: 'docs',
+      label: 'Docs',
+      iconToken: DsSidebarIconToken.projects,
+    ),
+  ];
+
+  void _goToSection(String id) {
+    setState(() => _activeSidebarId = id);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) {
+        return;
+      }
+      final BuildContext? targetContext = _sectionKeys[id]?.currentContext;
+      if (targetContext == null) {
+        return;
+      }
+      Scrollable.ensureVisible(
+        targetContext,
+        duration: const Duration(milliseconds: 260),
+        curve: Curves.easeInOut,
+        alignment: 0.02,
+      );
+    });
+  }
+
+  Widget _sectionAnchor(String id) {
+    return SizedBox(key: _sectionKeys[id], height: 1);
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -66,319 +158,420 @@ class ShowcaseScreen extends StatelessWidget {
         .toList();
 
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Pragma Design System'),
-        actions: <Widget>[
-          Row(
-            children: <Widget>[
-              Icon(
-                Icons.light_mode,
-                size: 18,
-                color: onSurfaceVariant,
-              ),
-              Switch(
-                value: mode == ThemeMode.dark,
-                onChanged: onModeChanged,
-              ),
-              Icon(
-                Icons.dark_mode,
-                size: 18,
-                color: onSurfaceVariant,
-              ),
-              const SizedBox(width: PragmaSpacing.md),
-            ],
-          ),
-          IconButton(
-            tooltip: 'Grid debugger',
-            icon: const Icon(Icons.grid_4x4_outlined),
-            onPressed: () => _openGridDebugger(context),
-          ),
-          IconButton(
-            tooltip: 'Calendar demo',
-            icon: const Icon(Icons.event_note_outlined),
-            onPressed: () => _openCalendarDemo(context),
-          ),
-          IconButton(
-            tooltip: 'Theme lab',
-            icon: const Icon(Icons.palette_outlined),
-            onPressed: () => _openThemeLab(context),
-          ),
-          IconButton(
-            tooltip: 'Page scaffold demo',
-            icon: const Icon(Icons.dashboard_customize_outlined),
-            onPressed: () => _openPragmaPageScaffold(context),
-          ),
-        ],
-      ),
-      body: ListView(
-        padding: PragmaSpacing.insetSymmetric(
-          horizontal: PragmaSpacing.xl,
-          vertical: PragmaSpacing.xl,
-        ),
+      body: Row(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
         children: <Widget>[
-          const _LogoShowcase(),
-          const SizedBox(height: PragmaSpacing.lg),
-          Text('Paleta cromática', style: textTheme.headlineSmall),
-          const SizedBox(height: PragmaSpacing.md),
-          Text(
-            'Visualiza los tokens de color incluidos en la librería y cómo se agrupan por intención.',
-            style: textTheme.bodyMedium?.copyWith(color: onSurfaceVariant),
-          ),
-          const SizedBox(height: PragmaSpacing.lg),
-          for (final _PaletteSection section in _paletteSections)
-            _PaletteSectionView(section: section),
-          const SizedBox(height: PragmaSpacing.lg),
-          const _ColorTokenRowPlayground(),
-          const SizedBox(height: PragmaSpacing.lg),
-          Text('Componentes base', style: textTheme.headlineSmall),
-          const SizedBox(height: PragmaSpacing.md),
-          Wrap(
-            spacing: PragmaSpacing.md,
-            runSpacing: PragmaSpacing.md,
-            children: <Widget>[
-              const PragmaPrimaryButton(
-                label: 'Primario',
-                onPressed: _noop,
-              ),
-              const PragmaPrimaryButton(
-                label: 'Primario inverso',
-                tone: PragmaButtonTone.inverse,
-                onPressed: _noop,
-              ),
-              const PragmaSecondaryButton(
-                label: 'Secundario',
-                onPressed: _noop,
-              ),
-              const PragmaTertiaryButton(
-                label: 'Terciario',
-                onPressed: _noop,
-              ),
-              const PragmaSecondaryButton(
-                label: 'Secundario small',
-                size: PragmaButtonSize.small,
-                onPressed: _noop,
-              ),
-              PragmaButton.icon(
-                label: 'Texto con ícono',
-                icon: Icons.arrow_forward,
-                hierarchy: PragmaButtonHierarchy.tertiary,
-                onPressed: _noop,
-              ),
-              const PragmaIconButtonWidget(
-                icon: Icons.favorite,
-                onPressed: _noop,
-                tooltip: 'Favorito',
-                style: PragmaIconButtonStyle.filledLight,
-              ),
-              const PragmaIconButtonWidget(
-                icon: Icons.palette,
-                tooltip: 'Deshabilitado',
-                style: PragmaIconButtonStyle.outlinedLight,
-                onPressed: null,
-              ),
-              const PragmaAvatarWidget(
-                radius: PragmaSpacing.md,
-                initials: 'PD',
-                tooltip: 'Avatar estático',
-              ),
-              const PragmaBreadcrumbWidget(
-                items: <PragmaBreadcrumbItem>[
-                  PragmaBreadcrumbItem(label: 'Inicio'),
-                  PragmaBreadcrumbItem(label: 'Componentes'),
-                  PragmaBreadcrumbItem(label: 'Breadcrumb', isCurrent: true),
-                ],
-              ),
-            ],
-          ),
-          const SizedBox(height: PragmaSpacing.lg),
-          PragmaCard.section(
-            headline: 'Estado de diseño',
-            action: PragmaButton.icon(
-              label: 'Ver detalles',
-              icon: Icons.open_in_new,
-              hierarchy: PragmaButtonHierarchy.tertiary,
-              onPressed: _noop,
-            ),
-            body: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: <Widget>[
-                Text(
-                  'Tokens sincronizados',
-                  style: textTheme.titleMedium,
+          DsSidebarMenuWidget(
+            title: 'Showcase',
+            items: _sidebarItems,
+            activeId: _activeSidebarId,
+            collapsed: _sidebarCollapsed,
+            showCollapseToggle: false,
+            onItemTap: _goToSection,
+            footer: Center(
+              child: Text(
+                _sidebarCollapsed ? '©' : '© Pragma',
+                textAlign: TextAlign.center,
+                style: textTheme.labelSmall?.copyWith(
+                  color: colorScheme.onPrimary.withValues(alpha: 0.8),
                 ),
-                const SizedBox(height: PragmaSpacing.sm),
-                Text(
-                  'Mantén consistencia visual reutilizando estos componentes en cada squad.',
-                  style: textTheme.bodyMedium,
-                ),
-              ],
+              ),
             ),
           ),
-          const SizedBox(height: PragmaSpacing.lg),
-          Text('PragmaCardWidget', style: textTheme.headlineSmall),
-          const SizedBox(height: PragmaSpacing.md),
-          Wrap(
-            spacing: PragmaSpacing.lg,
-            runSpacing: PragmaSpacing.lg,
-            children: <Widget>[
-              SizedBox(
-                width: 360,
-                child: PragmaCardWidget(
-                  title: 'Actividad semanal',
-                  subtitle: 'Actualizado hace 5 min',
-                  metadata: Wrap(
-                    spacing: PragmaSpacing.xs,
-                    runSpacing: PragmaSpacing.xs,
-                    children: <Widget>[
-                      Chip(
-                        label: const Text('Squad Atlas'),
-                        backgroundColor: colorScheme.surfaceContainerHighest,
+          Expanded(
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                color: colorScheme.surface,
+                border: Border(
+                  left: BorderSide(color: colorScheme.outlineVariant),
+                ),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  SafeArea(
+                    bottom: false,
+                    child: Padding(
+                      padding: const EdgeInsets.only(
+                        top: PragmaSpacing.md,
+                        left: PragmaSpacing.lg,
+                        right: PragmaSpacing.lg,
                       ),
-                      Chip(
-                        label: const Text('Mobile'),
-                        backgroundColor: colorScheme.surfaceContainerHighest,
+                      child: DsHeaderWidget(
+                        title: 'Pragma Design System',
+                        actions: <Widget>[
+                          DsHeaderActionSurface(
+                            child: Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: <Widget>[
+                                Icon(
+                                  Icons.light_mode,
+                                  size: 18,
+                                  color: onSurfaceVariant,
+                                ),
+                                Switch(
+                                  value: widget.mode == ThemeMode.dark,
+                                  onChanged: widget.onModeChanged,
+                                ),
+                                Icon(
+                                  Icons.dark_mode,
+                                  size: 18,
+                                  color: onSurfaceVariant,
+                                ),
+                              ],
+                            ),
+                          ),
+                          IconButton(
+                            tooltip: 'Grid debugger',
+                            icon: const Icon(Icons.grid_4x4_outlined),
+                            onPressed: () => _openGridDebugger(context),
+                          ),
+                          IconButton(
+                            tooltip: 'Calendar demo',
+                            icon: const Icon(Icons.event_note_outlined),
+                            onPressed: () => _openCalendarDemo(context),
+                          ),
+                          IconButton(
+                            tooltip: 'Theme lab',
+                            icon: const Icon(Icons.palette_outlined),
+                            onPressed: () => _openThemeLab(context),
+                          ),
+                          IconButton(
+                            tooltip: 'Page scaffold demo',
+                            icon:
+                                const Icon(Icons.dashboard_customize_outlined),
+                            onPressed: () => _openPragmaPageScaffold(context),
+                          ),
+                          TextButton.icon(
+                            onPressed: () => setState(
+                              () => _sidebarCollapsed = !_sidebarCollapsed,
+                            ),
+                            icon: Icon(
+                              _sidebarCollapsed
+                                  ? Icons.keyboard_double_arrow_right
+                                  : Icons.keyboard_double_arrow_left,
+                            ),
+                            label: Text(
+                              _sidebarCollapsed ? 'Expandir' : 'Contraer',
+                            ),
+                          ),
+                        ],
                       ),
-                    ],
+                    ),
                   ),
-                  body: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: <Widget>[
-                      Text(
-                        'Sesiones totales',
-                        style: textTheme.titleMedium,
-                      ),
-                      const SizedBox(height: PragmaSpacing.xs),
-                      Text(
-                        '18.4K · +4.1% vs semana anterior',
-                        style: textTheme.bodyMedium?.copyWith(
-                          color: onSurfaceVariant,
+                  Expanded(
+                    child: SingleChildScrollView(
+                      child: Padding(
+                        padding: PragmaSpacing.insetSymmetric(
+                          horizontal: PragmaSpacing.xl,
+                          vertical: PragmaSpacing.lg,
                         ),
-                      ),
-                    ],
-                  ),
-                  variant: PragmaCardVariant.tonal,
-                  actions: <Widget>[
-                    PragmaButton.icon(
-                      label: 'Ver dashboard',
-                      icon: Icons.open_in_new,
-                      hierarchy: PragmaButtonHierarchy.tertiary,
-                      onPressed: _noop,
-                    ),
-                  ],
-                ),
-              ),
-              SizedBox(
-                width: 320,
-                child: PragmaCardWidget(
-                  title: 'Prototipo desktop',
-                  subtitle: 'Listo para pruebas internas',
-                  metadata: Text(
-                    'Actualizado por UX Research',
-                    style: textTheme.bodySmall?.copyWith(
-                      color: onSurfaceVariant,
-                    ),
-                  ),
-                  media: AspectRatio(
-                    aspectRatio: 4 / 3,
-                    child: DecoratedBox(
-                      decoration: BoxDecoration(
-                        gradient: LinearGradient(
-                          colors: <Color>[
-                            colorScheme.primaryContainer,
-                            colorScheme.secondaryContainer,
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: <Widget>[
+                            _sectionAnchor('overview'),
+                            const _LogoShowcase(),
+                            const SizedBox(height: PragmaSpacing.lg),
+                            _sectionAnchor('tokens'),
+                            Text('Paleta cromática',
+                                style: textTheme.headlineSmall),
+                            const SizedBox(height: PragmaSpacing.md),
+                            Text(
+                              'Visualiza los tokens de color incluidos en la librería y cómo se agrupan por intención.',
+                              style: textTheme.bodyMedium
+                                  ?.copyWith(color: onSurfaceVariant),
+                            ),
+                            const SizedBox(height: PragmaSpacing.lg),
+                            for (final _PaletteSection section
+                                in _paletteSections)
+                              _PaletteSectionView(section: section),
+                            const SizedBox(height: PragmaSpacing.lg),
+                            const _ColorTokenRowPlayground(),
+                            const SizedBox(height: PragmaSpacing.lg),
+                            _sectionAnchor('base'),
+                            Text('Componentes base',
+                                style: textTheme.headlineSmall),
+                            const SizedBox(height: PragmaSpacing.md),
+                            Wrap(
+                              spacing: PragmaSpacing.md,
+                              runSpacing: PragmaSpacing.md,
+                              children: <Widget>[
+                                const PragmaPrimaryButton(
+                                  label: 'Primario',
+                                  onPressed: _noop,
+                                ),
+                                const PragmaPrimaryButton(
+                                  label: 'Primario inverso',
+                                  tone: PragmaButtonTone.inverse,
+                                  onPressed: _noop,
+                                ),
+                                const PragmaSecondaryButton(
+                                  label: 'Secundario',
+                                  onPressed: _noop,
+                                ),
+                                const PragmaTertiaryButton(
+                                  label: 'Terciario',
+                                  onPressed: _noop,
+                                ),
+                                const PragmaSecondaryButton(
+                                  label: 'Secundario small',
+                                  size: PragmaButtonSize.small,
+                                  onPressed: _noop,
+                                ),
+                                PragmaButton.icon(
+                                  label: 'Texto con ícono',
+                                  icon: Icons.arrow_forward,
+                                  hierarchy: PragmaButtonHierarchy.tertiary,
+                                  onPressed: _noop,
+                                ),
+                                const PragmaIconButtonWidget(
+                                  icon: Icons.favorite,
+                                  onPressed: _noop,
+                                  tooltip: 'Favorito',
+                                  style: PragmaIconButtonStyle.filledLight,
+                                ),
+                                const PragmaIconButtonWidget(
+                                  icon: Icons.palette,
+                                  tooltip: 'Deshabilitado',
+                                  style: PragmaIconButtonStyle.outlinedLight,
+                                  onPressed: null,
+                                ),
+                                const PragmaAvatarWidget(
+                                  radius: PragmaSpacing.md,
+                                  initials: 'PD',
+                                  tooltip: 'Avatar estático',
+                                ),
+                                const PragmaBreadcrumbWidget(
+                                  items: <PragmaBreadcrumbItem>[
+                                    PragmaBreadcrumbItem(label: 'Inicio'),
+                                    PragmaBreadcrumbItem(label: 'Componentes'),
+                                    PragmaBreadcrumbItem(
+                                      label: 'Breadcrumb',
+                                      isCurrent: true,
+                                    ),
+                                  ],
+                                ),
+                              ],
+                            ),
+                            const SizedBox(height: PragmaSpacing.lg),
+                            PragmaCard.section(
+                              headline: 'Estado de diseño',
+                              action: PragmaButton.icon(
+                                label: 'Ver detalles',
+                                icon: Icons.open_in_new,
+                                hierarchy: PragmaButtonHierarchy.tertiary,
+                                onPressed: _noop,
+                              ),
+                              body: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: <Widget>[
+                                  Text(
+                                    'Tokens sincronizados',
+                                    style: textTheme.titleMedium,
+                                  ),
+                                  const SizedBox(height: PragmaSpacing.sm),
+                                  Text(
+                                    'Mantén consistencia visual reutilizando estos componentes en cada squad.',
+                                    style: textTheme.bodyMedium,
+                                  ),
+                                ],
+                              ),
+                            ),
+                            const SizedBox(height: PragmaSpacing.lg),
+                            Text('PragmaCardWidget',
+                                style: textTheme.headlineSmall),
+                            const SizedBox(height: PragmaSpacing.md),
+                            Wrap(
+                              spacing: PragmaSpacing.lg,
+                              runSpacing: PragmaSpacing.lg,
+                              children: <Widget>[
+                                SizedBox(
+                                  width: 360,
+                                  child: PragmaCardWidget(
+                                    title: 'Actividad semanal',
+                                    subtitle: 'Actualizado hace 5 min',
+                                    metadata: Wrap(
+                                      spacing: PragmaSpacing.xs,
+                                      runSpacing: PragmaSpacing.xs,
+                                      children: <Widget>[
+                                        Chip(
+                                          label: const Text('Squad Atlas'),
+                                          backgroundColor: colorScheme
+                                              .surfaceContainerHighest,
+                                        ),
+                                        Chip(
+                                          label: const Text('Mobile'),
+                                          backgroundColor: colorScheme
+                                              .surfaceContainerHighest,
+                                        ),
+                                      ],
+                                    ),
+                                    body: Column(
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.start,
+                                      children: <Widget>[
+                                        Text(
+                                          'Sesiones totales',
+                                          style: textTheme.titleMedium,
+                                        ),
+                                        const SizedBox(
+                                            height: PragmaSpacing.xs),
+                                        Text(
+                                          '18.4K · +4.1% vs semana anterior',
+                                          style: textTheme.bodyMedium?.copyWith(
+                                            color: onSurfaceVariant,
+                                          ),
+                                        ),
+                                      ],
+                                    ),
+                                    variant: PragmaCardVariant.tonal,
+                                    actions: <Widget>[
+                                      PragmaButton.icon(
+                                        label: 'Ver dashboard',
+                                        icon: Icons.open_in_new,
+                                        hierarchy:
+                                            PragmaButtonHierarchy.tertiary,
+                                        onPressed: _noop,
+                                      ),
+                                    ],
+                                  ),
+                                ),
+                                SizedBox(
+                                  width: 320,
+                                  child: PragmaCardWidget(
+                                    title: 'Prototipo desktop',
+                                    subtitle: 'Listo para pruebas internas',
+                                    metadata: Text(
+                                      'Actualizado por UX Research',
+                                      style: textTheme.bodySmall?.copyWith(
+                                        color: onSurfaceVariant,
+                                      ),
+                                    ),
+                                    media: AspectRatio(
+                                      aspectRatio: 4 / 3,
+                                      child: DecoratedBox(
+                                        decoration: BoxDecoration(
+                                          gradient: LinearGradient(
+                                            colors: <Color>[
+                                              colorScheme.primaryContainer,
+                                              colorScheme.secondaryContainer,
+                                            ],
+                                          ),
+                                        ),
+                                        child: const Center(
+                                          child:
+                                              Icon(Icons.view_in_ar, size: 48),
+                                        ),
+                                      ),
+                                    ),
+                                    body: Text(
+                                      'Comparte enlaces a los archivos clave sin perder el contexto visual.',
+                                      style: textTheme.bodyMedium,
+                                    ),
+                                    size: PragmaCardSize.small,
+                                    variant: PragmaCardVariant.outlined,
+                                    actions: <Widget>[
+                                      TextButton.icon(
+                                        onPressed: _noop,
+                                        icon: const Icon(
+                                            Icons.visibility_outlined),
+                                        label: const Text('Abrir preview'),
+                                      ),
+                                    ],
+                                  ),
+                                ),
+                              ],
+                            ),
+                            const SizedBox(height: PragmaSpacing.lg),
+                            Text(
+                              'PragmaAccordionWidget',
+                              style: textTheme.headlineSmall,
+                            ),
+                            const SizedBox(height: PragmaSpacing.md),
+                            PragmaAccordionWidget(
+                              text: 'Resumen del sprint',
+                              icon: Icons.calendar_today_outlined,
+                              child: Text(
+                                'Comparte acuerdos, links a tableros y métricas clave sin saturar la vista principal.',
+                                style: textTheme.bodyMedium,
+                              ),
+                            ),
+                            const SizedBox(height: PragmaSpacing.md),
+                            const PragmaAccordionWidget(
+                              text: 'Checklist bloqueado',
+                              icon: Icons.lock_outline,
+                              disable: true,
+                              size: PragmaAccordionSize.block,
+                              child: Text(
+                                'Este panel permanece cerrado hasta habilitar el flujo.',
+                              ),
+                            ),
+                            const SizedBox(height: PragmaSpacing.lg),
+                            _sectionAnchor('navigation'),
+                            const _SidebarMenuShowcase(),
+                            const SizedBox(height: PragmaSpacing.lg),
+                            _sectionAnchor('forms'),
+                            const _InputPlayground(),
+                            const SizedBox(height: PragmaSpacing.lg),
+                            const _TextAreaShowcase(),
+                            const SizedBox(height: PragmaSpacing.lg),
+                            const _TagShowcase(),
+                            const SizedBox(height: PragmaSpacing.lg),
+                            const _BadgeShowcase(),
+                            const SizedBox(height: PragmaSpacing.lg),
+                            const _CheckboxShowcase(),
+                            const SizedBox(height: PragmaSpacing.lg),
+                            const _RadioButtonShowcase(),
+                            const SizedBox(height: PragmaSpacing.lg),
+                            _sectionAnchor('feedback'),
+                            const _ToastPlayground(),
+                            const SizedBox(height: PragmaSpacing.lg),
+                            const _LoadingShowcase(),
+                            const SizedBox(height: PragmaSpacing.lg),
+                            const _StepperShowcase(),
+                            const SizedBox(height: PragmaSpacing.lg),
+                            _sectionAnchor('data'),
+                            const _TableShowcase(),
+                            const SizedBox(height: PragmaSpacing.lg),
+                            const _PaginationShowcase(),
+                            const SizedBox(height: PragmaSpacing.lg),
+                            const _FilterShowcase(),
+                            const SizedBox(height: PragmaSpacing.lg),
+                            _sectionAnchor('overlays'),
+                            const _TooltipShowcase(),
+                            const SizedBox(height: PragmaSpacing.lg),
+                            const _SearchShowcase(),
+                            const SizedBox(height: PragmaSpacing.lg),
+                            const _DropdownPlayground(),
+                            const SizedBox(height: PragmaSpacing.lg),
+                            const _DropdownListPlayground(),
+                            const SizedBox(height: PragmaSpacing.lg),
+                            const _AvatarPlayground(),
+                            const SizedBox(height: PragmaSpacing.lg),
+                            const _BreadcrumbPlayground(),
+                            const SizedBox(height: PragmaSpacing.lg),
+                            const _IconButtonPlayground(),
+                            const SizedBox(height: PragmaSpacing.lg),
+                            _sectionAnchor('docs'),
+                            Text(
+                              'Componentes documentados',
+                              style: textTheme.headlineSmall,
+                            ),
+                            const SizedBox(height: PragmaSpacing.md),
+                            Column(
+                              children: documentedComponents
+                                  .map((ModelPragmaComponent component) {
+                                return _ComponentDocCard(component: component);
+                              }).toList(),
+                            ),
                           ],
                         ),
                       ),
-                      child: const Center(
-                        child: Icon(Icons.view_in_ar, size: 48),
-                      ),
                     ),
                   ),
-                  body: Text(
-                    'Comparte enlaces a los archivos clave sin perder el contexto visual.',
-                    style: textTheme.bodyMedium,
-                  ),
-                  size: PragmaCardSize.small,
-                  variant: PragmaCardVariant.outlined,
-                  actions: <Widget>[
-                    TextButton.icon(
-                      onPressed: _noop,
-                      icon: const Icon(Icons.visibility_outlined),
-                      label: const Text('Abrir preview'),
-                    ),
-                  ],
-                ),
+                ],
               ),
-            ],
-          ),
-          const SizedBox(height: PragmaSpacing.lg),
-          Text('PragmaAccordionWidget', style: textTheme.headlineSmall),
-          const SizedBox(height: PragmaSpacing.md),
-          PragmaAccordionWidget(
-            text: 'Resumen del sprint',
-            icon: Icons.calendar_today_outlined,
-            child: Text(
-              'Comparte acuerdos, links a tableros y métricas clave sin saturar la vista principal.',
-              style: textTheme.bodyMedium,
             ),
-          ),
-          const SizedBox(height: PragmaSpacing.md),
-          const PragmaAccordionWidget(
-            text: 'Checklist bloqueado',
-            icon: Icons.lock_outline,
-            disable: true,
-            size: PragmaAccordionSize.block,
-            child:
-                Text('Este panel permanece cerrado hasta habilitar el flujo.'),
-          ),
-          const SizedBox(height: PragmaSpacing.lg),
-          const _SidebarMenuShowcase(),
-          const SizedBox(height: PragmaSpacing.lg),
-          const _InputPlayground(),
-          const SizedBox(height: PragmaSpacing.lg),
-          const _TextAreaShowcase(),
-          const SizedBox(height: PragmaSpacing.lg),
-          const _TagShowcase(),
-          const SizedBox(height: PragmaSpacing.lg),
-          const _BadgeShowcase(),
-          const SizedBox(height: PragmaSpacing.lg),
-          const _CheckboxShowcase(),
-          const SizedBox(height: PragmaSpacing.lg),
-          const _RadioButtonShowcase(),
-          const SizedBox(height: PragmaSpacing.lg),
-          const _ToastPlayground(),
-          const SizedBox(height: PragmaSpacing.lg),
-          const _LoadingShowcase(),
-          const SizedBox(height: PragmaSpacing.lg),
-          const _StepperShowcase(),
-          const SizedBox(height: PragmaSpacing.lg),
-          const _TableShowcase(),
-          const SizedBox(height: PragmaSpacing.lg),
-          const _PaginationShowcase(),
-          const SizedBox(height: PragmaSpacing.lg),
-          const _FilterShowcase(),
-          const SizedBox(height: PragmaSpacing.lg),
-          const _TooltipShowcase(),
-          const SizedBox(height: PragmaSpacing.lg),
-          const _SearchShowcase(),
-          const SizedBox(height: PragmaSpacing.lg),
-          const _DropdownPlayground(),
-          const SizedBox(height: PragmaSpacing.lg),
-          const _DropdownListPlayground(),
-          const SizedBox(height: PragmaSpacing.lg),
-          const _AvatarPlayground(),
-          const SizedBox(height: PragmaSpacing.lg),
-          const _BreadcrumbPlayground(),
-          const SizedBox(height: PragmaSpacing.lg),
-          const _IconButtonPlayground(),
-          const SizedBox(height: PragmaSpacing.lg),
-          Text('Componentes documentados', style: textTheme.headlineSmall),
-          const SizedBox(height: PragmaSpacing.md),
-          Column(
-            children:
-                documentedComponents.map((ModelPragmaComponent component) {
-              return _ComponentDocCard(component: component);
-            }).toList(),
           ),
         ],
       ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -7,6 +7,7 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:pragma_design_system/pragma_design_system.dart';
 
 import 'calendar_demo_page.dart';
+import 'pragma_page_scaffold.dart';
 import 'theme_lab_page.dart';
 
 // Consumimos la librería local directamente para iterar sin publicar a pub.dev.
@@ -101,6 +102,11 @@ class ShowcaseScreen extends StatelessWidget {
             tooltip: 'Theme lab',
             icon: const Icon(Icons.palette_outlined),
             onPressed: () => _openThemeLab(context),
+          ),
+          IconButton(
+            tooltip: 'Page scaffold demo',
+            icon: const Icon(Icons.dashboard_customize_outlined),
+            onPressed: () => _openPragmaPageScaffold(context),
           ),
         ],
       ),
@@ -326,6 +332,8 @@ class ShowcaseScreen extends StatelessWidget {
                 Text('Este panel permanece cerrado hasta habilitar el flujo.'),
           ),
           const SizedBox(height: PragmaSpacing.lg),
+          const _SidebarMenuShowcase(),
+          const SizedBox(height: PragmaSpacing.lg),
           const _InputPlayground(),
           const SizedBox(height: PragmaSpacing.lg),
           const _TextAreaShowcase(),
@@ -400,6 +408,14 @@ void _openThemeLab(BuildContext context) {
   Navigator.of(context).push(
     MaterialPageRoute<void>(
       builder: (_) => const ThemeLabPage(),
+    ),
+  );
+}
+
+void _openPragmaPageScaffold(BuildContext context) {
+  Navigator.of(context).push(
+    MaterialPageRoute<void>(
+      builder: (_) => const PragmaPageScaffold(),
     ),
   );
 }
@@ -929,6 +945,117 @@ class _TextAreaShowcase extends StatefulWidget {
 
   @override
   State<_TextAreaShowcase> createState() => _TextAreaShowcaseState();
+}
+
+class _SidebarMenuShowcase extends StatefulWidget {
+  const _SidebarMenuShowcase();
+
+  @override
+  State<_SidebarMenuShowcase> createState() => _SidebarMenuShowcaseState();
+}
+
+class _SidebarMenuShowcaseState extends State<_SidebarMenuShowcase> {
+  bool _collapsed = false;
+  String _activeId = 'dashboard';
+
+  static final List<ModelDsSidebarMenuItem> _items = <ModelDsSidebarMenuItem>[
+    ModelDsSidebarMenuItem(
+      id: 'dashboard',
+      label: 'Dashboard',
+      iconToken: DsSidebarIconToken.dashboard,
+    ),
+    ModelDsSidebarMenuItem(
+      id: 'projects',
+      label: 'Proyectos',
+      iconToken: DsSidebarIconToken.projects,
+    ),
+    ModelDsSidebarMenuItem(
+      id: 'reports',
+      label: 'Reportes',
+      iconToken: DsSidebarIconToken.reports,
+    ),
+    ModelDsSidebarMenuItem(
+      id: 'settings',
+      label: 'Configuracion',
+      iconToken: DsSidebarIconToken.settings,
+      enabled: false,
+    ),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme textTheme = Theme.of(context).textTheme;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Text('DsSidebarMenuWidget', style: textTheme.headlineSmall),
+        const SizedBox(height: PragmaSpacing.md),
+        Wrap(
+          spacing: PragmaSpacing.lg,
+          runSpacing: PragmaSpacing.lg,
+          crossAxisAlignment: WrapCrossAlignment.start,
+          children: <Widget>[
+            DsSidebarMenuWidget(
+              title: 'Creci',
+              items: _items,
+              activeId: _activeId,
+              collapsed: _collapsed,
+              onItemTap: (String id) => setState(() => _activeId = id),
+              onCollapsedToggle: (bool next) =>
+                  setState(() => _collapsed = next),
+              footer: const Padding(
+                padding: EdgeInsets.only(top: PragmaSpacing.sm),
+                child: Text(
+                  'v2.0.0 · made by Prag',
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            ),
+            SizedBox(
+              width: 320,
+              child: PragmaCard.section(
+                headline: 'Configura sidebar',
+                body: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    SwitchListTile.adaptive(
+                      contentPadding: EdgeInsets.zero,
+                      title: const Text('Collapsed'),
+                      value: _collapsed,
+                      onChanged: (bool value) =>
+                          setState(() => _collapsed = value),
+                    ),
+                    const SizedBox(height: PragmaSpacing.xs),
+                    Text(
+                      'Activo: $_activeId',
+                      style: textTheme.labelLarge,
+                    ),
+                    const SizedBox(height: PragmaSpacing.sm),
+                    Wrap(
+                      spacing: PragmaSpacing.xs,
+                      runSpacing: PragmaSpacing.xs,
+                      children: _items
+                          .where((ModelDsSidebarMenuItem item) => item.enabled)
+                          .map(
+                            (ModelDsSidebarMenuItem item) => ChoiceChip(
+                              label: Text(item.label),
+                              selected: _activeId == item.id,
+                              onSelected: (_) =>
+                                  setState(() => _activeId = item.id),
+                            ),
+                          )
+                          .toList(),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
 }
 
 class _TextAreaShowcaseState extends State<_TextAreaShowcase> {

--- a/example/lib/pragma_page_scaffold.dart
+++ b/example/lib/pragma_page_scaffold.dart
@@ -1,0 +1,208 @@
+import 'package:flutter/material.dart';
+import 'package:pragma_design_system/pragma_design_system.dart';
+
+class PragmaPageScaffold extends StatefulWidget {
+  const PragmaPageScaffold({super.key});
+
+  @override
+  State<PragmaPageScaffold> createState() => _PragmaPageScaffoldState();
+}
+
+class _PragmaPageScaffoldState extends State<PragmaPageScaffold> {
+  bool _collapsed = false;
+  String _activeId = 'dashboard';
+
+  static final List<ModelDsSidebarMenuItem> _items = <ModelDsSidebarMenuItem>[
+    ModelDsSidebarMenuItem(
+      id: 'back',
+      label: 'Volver',
+      iconToken: DsSidebarIconToken.back,
+    ),
+    ModelDsSidebarMenuItem(
+      id: 'dashboard',
+      label: 'Dashboard',
+      iconToken: DsSidebarIconToken.dashboard,
+    ),
+    ModelDsSidebarMenuItem(
+      id: 'projects',
+      label: 'Proyectos',
+      iconToken: DsSidebarIconToken.projects,
+    ),
+    ModelDsSidebarMenuItem(
+      id: 'reports',
+      label: 'Reportes',
+      iconToken: DsSidebarIconToken.reports,
+    ),
+    ModelDsSidebarMenuItem(
+      id: 'settings',
+      label: 'Configuracion',
+      iconToken: DsSidebarIconToken.settings,
+    ),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final TextTheme textTheme = theme.textTheme;
+    final ColorScheme scheme = theme.colorScheme;
+
+    return Scaffold(
+      body: SizedBox.expand(
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: <Widget>[
+            DsSidebarMenuWidget(
+              title: 'Creci',
+              items: _items,
+              activeId: _activeId,
+              collapsed: _collapsed,
+              onItemTap: (String id) {
+                if (id == 'back') {
+                  Navigator.of(context).maybePop();
+                  return;
+                }
+                setState(() => _activeId = id);
+              },
+              footer: Center(
+                child: Text(
+                  _collapsed ? '©' : '© Pragma',
+                  textAlign: TextAlign.center,
+                  style: textTheme.labelSmall?.copyWith(
+                    color: scheme.onPrimary.withValues(alpha: 0.8),
+                  ),
+                ),
+              ),
+              showCollapseToggle: false,
+            ),
+            Expanded(
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  color: scheme.surface,
+                  border: Border(
+                    left: BorderSide(color: scheme.outlineVariant),
+                  ),
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.all(PragmaSpacing.lg),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: <Widget>[
+                      Row(
+                        children: <Widget>[
+                          Text(
+                            'Area de trabajo',
+                            style: textTheme.headlineSmall,
+                          ),
+                          const Spacer(),
+                          TextButton.icon(
+                            onPressed: () =>
+                                setState(() => _collapsed = !_collapsed),
+                            icon: Icon(
+                              _collapsed
+                                  ? Icons.keyboard_double_arrow_right
+                                  : Icons.keyboard_double_arrow_left,
+                            ),
+                            label: Text(
+                              _collapsed ? 'Expandir' : 'Contraer',
+                            ),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: PragmaSpacing.xs),
+                      Text(
+                        'Vista activa: $_activeId',
+                        style: textTheme.bodyMedium?.copyWith(
+                          color: scheme.onSurfaceVariant,
+                        ),
+                      ),
+                      const SizedBox(height: PragmaSpacing.md),
+                      Expanded(
+                        child: GridView.count(
+                          crossAxisCount: 2,
+                          crossAxisSpacing: PragmaSpacing.md,
+                          mainAxisSpacing: PragmaSpacing.md,
+                          childAspectRatio: 1.6,
+                          children: const <Widget>[
+                            _WorkspaceCard(
+                              title: 'Resumen',
+                              subtitle: 'KPIs y estado general del squad',
+                              icon: Icons.insights_outlined,
+                            ),
+                            _WorkspaceCard(
+                              title: 'Tareas',
+                              subtitle: 'Backlog y seguimiento de issues',
+                              icon: Icons.task_alt,
+                            ),
+                            _WorkspaceCard(
+                              title: 'Releases',
+                              subtitle: 'Versionado y cambios pendientes',
+                              icon: Icons.rocket_launch_outlined,
+                            ),
+                            _WorkspaceCard(
+                              title: 'Alertas',
+                              subtitle: 'Eventos de QA y observabilidad',
+                              icon: Icons.notifications_active_outlined,
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _WorkspaceCard extends StatelessWidget {
+  const _WorkspaceCard({
+    required this.title,
+    required this.subtitle,
+    required this.icon,
+  });
+
+  final String title;
+  final String subtitle;
+  final IconData icon;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme scheme = theme.colorScheme;
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: scheme.surfaceContainerLowest,
+        borderRadius:
+            PragmaBorderRadius.circularToken(PragmaBorderRadiusTokens.l),
+        border: Border.all(color: scheme.outlineVariant),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(PragmaSpacing.md),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Icon(icon, color: scheme.primary),
+            const SizedBox(height: PragmaSpacing.xs),
+            Text(title, style: theme.textTheme.titleMedium),
+            const SizedBox(height: PragmaSpacing.xs),
+            Expanded(
+              child: Text(
+                subtitle,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: scheme.onSurfaceVariant,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/pragma_page_scaffold.dart
+++ b/example/lib/pragma_page_scaffold.dart
@@ -87,13 +87,25 @@ class _PragmaPageScaffoldState extends State<PragmaPageScaffold> {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: <Widget>[
-                      Row(
-                        children: <Widget>[
-                          Text(
-                            'Area de trabajo',
-                            style: textTheme.headlineSmall,
+                      DsHeaderWidget(
+                        title: 'Area de trabajo',
+                        actions: <Widget>[
+                          DsHeaderActionSurface(
+                            child: Text(
+                              'Ambiente: demo',
+                              style: textTheme.labelMedium,
+                            ),
                           ),
-                          const Spacer(),
+                          IconButton(
+                            tooltip: 'Buscar',
+                            onPressed: () {},
+                            icon: const Icon(Icons.search),
+                          ),
+                          IconButton(
+                            tooltip: 'Alertas',
+                            onPressed: () {},
+                            icon: const Icon(Icons.notifications_outlined),
+                          ),
                           TextButton.icon(
                             onPressed: () =>
                                 setState(() => _collapsed = !_collapsed),
@@ -102,9 +114,12 @@ class _PragmaPageScaffoldState extends State<PragmaPageScaffold> {
                                   ? Icons.keyboard_double_arrow_right
                                   : Icons.keyboard_double_arrow_left,
                             ),
-                            label: Text(
-                              _collapsed ? 'Expandir' : 'Contraer',
-                            ),
+                            label: Text(_collapsed ? 'Expandir' : 'Contraer'),
+                          ),
+                          const PragmaAvatarWidget(
+                            radius: PragmaSpacing.sm,
+                            initials: 'PD',
+                            semanticLabel: 'Avatar de usuario',
                           ),
                         ],
                       ),

--- a/lib/pragma_design_system.dart
+++ b/lib/pragma_design_system.dart
@@ -4,10 +4,17 @@ library pragma_design_system;
 
 export 'src/domain/models/model_anatomy_attribute.dart';
 export 'src/domain/models/model_color_token.dart';
+export 'src/domain/models/model_design_system.dart';
+export 'src/domain/models/model_ds_component_anatomy.dart';
+export 'src/domain/models/model_ds_dataviz_palette.dart';
+export 'src/domain/models/model_ds_extended_tokens.dart';
 export 'src/domain/models/model_ds_sidebar_menu_item.dart';
 export 'src/domain/models/model_field_state.dart';
 export 'src/domain/models/model_pragma_component.dart';
+export 'src/domain/models/model_semantic_colors.dart';
+export 'src/domain/models/model_theme_data.dart';
 export 'src/domain/models/model_theme_pragma.dart';
+export 'src/domain/models/model_typography_tokens.dart';
 export 'src/layout/pragma_grid.dart';
 export 'src/layout/pragma_grid_container.dart';
 export 'src/layout/pragma_scale_box.dart';

--- a/lib/pragma_design_system.dart
+++ b/lib/pragma_design_system.dart
@@ -20,6 +20,7 @@ export 'src/tokens/pragma_grid_tokens.dart';
 export 'src/tokens/pragma_opacity.dart';
 export 'src/tokens/pragma_spacing.dart';
 export 'src/tokens/pragma_typography.dart';
+export 'src/widgets/ds_header_widget.dart';
 export 'src/widgets/ds_sidebar_menu_widget.dart';
 export 'src/widgets/pragma_accordion_widget.dart';
 export 'src/widgets/pragma_avatar_widget.dart';

--- a/lib/pragma_design_system.dart
+++ b/lib/pragma_design_system.dart
@@ -20,6 +20,7 @@ export 'src/tokens/pragma_grid_tokens.dart';
 export 'src/tokens/pragma_opacity.dart';
 export 'src/tokens/pragma_spacing.dart';
 export 'src/tokens/pragma_typography.dart';
+export 'src/widgets/ds_sidebar_menu_widget.dart';
 export 'src/widgets/pragma_accordion_widget.dart';
 export 'src/widgets/pragma_avatar_widget.dart';
 export 'src/widgets/pragma_badge_widget.dart';

--- a/lib/pragma_design_system.dart
+++ b/lib/pragma_design_system.dart
@@ -4,6 +4,7 @@ library pragma_design_system;
 
 export 'src/domain/models/model_anatomy_attribute.dart';
 export 'src/domain/models/model_color_token.dart';
+export 'src/domain/models/model_ds_sidebar_menu_item.dart';
 export 'src/domain/models/model_field_state.dart';
 export 'src/domain/models/model_pragma_component.dart';
 export 'src/domain/models/model_theme_pragma.dart';

--- a/lib/src/domain/models/model_design_system.dart
+++ b/lib/src/domain/models/model_design_system.dart
@@ -1,0 +1,280 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+import '../../tokens/pragma_typography.dart';
+import 'model_ds_dataviz_palette.dart';
+import 'model_ds_extended_tokens.dart';
+import 'model_semantic_colors.dart';
+import 'model_theme_data.dart';
+import 'model_typography_tokens.dart';
+
+abstract final class ModelDesignSystemKeys {
+  static const String theme = 'theme';
+  static const String tokens = 'tokens';
+  static const String semanticLight = 'semanticLight';
+  static const String semanticDark = 'semanticDark';
+  static const String dataViz = 'dataViz';
+  static const String typographyTokens = 'typographyTokens';
+}
+
+@immutable
+class ModelDesignSystem {
+  const ModelDesignSystem({
+    required this.theme,
+    required this.tokens,
+    required this.semanticLight,
+    required this.semanticDark,
+    required this.dataViz,
+    required this.typographyTokens,
+  });
+
+  factory ModelDesignSystem.pragmaDefault() {
+    return ModelDesignSystem(
+      theme: ModelThemeData.pragmaDefault(),
+      tokens: const DsExtendedTokens(),
+      semanticLight: ModelSemanticColors.fallbackLight(),
+      semanticDark: ModelSemanticColors.fallbackDark(),
+      dataViz: ModelDataVizPalette.fallback(),
+      typographyTokens: ModelTypographyTokens.pragmaDefault(),
+    );
+  }
+
+  factory ModelDesignSystem.fromJson(Map<String, dynamic> json) {
+    final Object? themeRaw = json[ModelDesignSystemKeys.theme];
+    final Object? tokensRaw = json[ModelDesignSystemKeys.tokens];
+
+    if (themeRaw is! Map<String, dynamic>) {
+      throw const FormatException('Expected map for theme');
+    }
+    if (tokensRaw is! Map<String, dynamic>) {
+      throw const FormatException('Expected map for tokens');
+    }
+
+    final Object? semanticLightRaw = json[ModelDesignSystemKeys.semanticLight];
+    final Object? semanticDarkRaw = json[ModelDesignSystemKeys.semanticDark];
+    final Object? dataVizRaw = json[ModelDesignSystemKeys.dataViz];
+    final Object? typographyTokensRaw =
+        json[ModelDesignSystemKeys.typographyTokens];
+
+    return ModelDesignSystem(
+      theme: ModelThemeData.fromJson(themeRaw),
+      tokens: DsExtendedTokens.fromJson(tokensRaw),
+      semanticLight: semanticLightRaw is Map<String, dynamic>
+          ? ModelSemanticColors.fromJson(semanticLightRaw)
+          : ModelSemanticColors.fallbackLight(),
+      semanticDark: semanticDarkRaw is Map<String, dynamic>
+          ? ModelSemanticColors.fromJson(semanticDarkRaw)
+          : ModelSemanticColors.fallbackDark(),
+      dataViz: dataVizRaw is Map<String, dynamic>
+          ? ModelDataVizPalette.fromJson(dataVizRaw)
+          : ModelDataVizPalette.fallback(),
+      typographyTokens: typographyTokensRaw is Map<String, dynamic>
+          ? ModelTypographyTokens.fromJson(typographyTokensRaw)
+          : ModelTypographyTokens.pragmaDefault(),
+    );
+  }
+
+  final ModelThemeData theme;
+  final DsExtendedTokens tokens;
+  final ModelSemanticColors semanticLight;
+  final ModelSemanticColors semanticDark;
+  final ModelDataVizPalette dataViz;
+  final ModelTypographyTokens typographyTokens;
+
+  ModelDesignSystem copyWith({
+    ModelThemeData? theme,
+    DsExtendedTokens? tokens,
+    ModelSemanticColors? semanticLight,
+    ModelSemanticColors? semanticDark,
+    ModelDataVizPalette? dataViz,
+    ModelTypographyTokens? typographyTokens,
+  }) {
+    return ModelDesignSystem(
+      theme: theme ?? this.theme,
+      tokens: tokens ?? this.tokens,
+      semanticLight: semanticLight ?? this.semanticLight,
+      semanticDark: semanticDark ?? this.semanticDark,
+      dataViz: dataViz ?? this.dataViz,
+      typographyTokens: typographyTokens ?? this.typographyTokens,
+    );
+  }
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        ModelDesignSystemKeys.theme: theme.toJson(),
+        ModelDesignSystemKeys.tokens: tokens.toJson(),
+        ModelDesignSystemKeys.semanticLight: semanticLight.toJson(),
+        ModelDesignSystemKeys.semanticDark: semanticDark.toJson(),
+        ModelDesignSystemKeys.dataViz: dataViz.toJson(),
+        ModelDesignSystemKeys.typographyTokens: typographyTokens.toJson(),
+      };
+
+  ThemeData toThemeData({required Brightness brightness}) {
+    final ModelThemeData themed = theme.copyWith(
+      lightTextTheme: PragmaTypography.textThemeFromTokens(
+        typographyTokens: typographyTokens,
+      ),
+      darkTextTheme: PragmaTypography.textThemeFromTokens(
+        typographyTokens: typographyTokens,
+        brightness: Brightness.dark,
+      ),
+    );
+
+    final ThemeData base = themed.toThemeData(brightness: brightness);
+    final ModelSemanticColors semantic =
+        brightness == Brightness.dark ? semanticDark : semanticLight;
+
+    final ThemeData withExtensions = base.copyWith(
+      extensions: <ThemeExtension<dynamic>>[
+        DsExtendedTokensExtension(tokens: tokens),
+        DsSemanticColorsExtension(semantic: semantic),
+        DsDataVizPaletteExtension(palette: dataViz),
+      ],
+    );
+
+    return _applyComponentTheme(withExtensions);
+  }
+
+  ThemeData _applyComponentTheme(ThemeData t) {
+    final ColorScheme cs = t.colorScheme;
+    final BorderRadius radius = BorderRadius.circular(tokens.borderRadius);
+    final BorderRadius radiusLg = BorderRadius.circular(tokens.borderRadiusLg);
+
+    return t.copyWith(
+      cardTheme: CardThemeData(
+        color: cs.surface,
+        elevation: tokens.elevation,
+        shape: RoundedRectangleBorder(borderRadius: radiusLg),
+      ),
+      inputDecorationTheme: InputDecorationTheme(
+        border: OutlineInputBorder(borderRadius: radius),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: radius,
+          borderSide: BorderSide(color: cs.outlineVariant),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: radius,
+          borderSide: BorderSide(color: cs.primary, width: 1.4),
+        ),
+        contentPadding: EdgeInsets.symmetric(
+          horizontal: tokens.spacing,
+          vertical: tokens.spacingSm,
+        ),
+      ),
+      dividerTheme: DividerThemeData(
+        color: cs.outlineVariant,
+        thickness: 1,
+        space: tokens.spacing,
+      ),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (other is! ModelDesignSystem) {
+      return false;
+    }
+    return mapEquals(toJson(), other.toJson());
+  }
+
+  @override
+  int get hashCode => Object.hashAll(<Object?>[
+        theme,
+        tokens,
+        semanticLight,
+        semanticDark,
+        dataViz,
+        typographyTokens,
+      ]);
+}
+
+@immutable
+class DsExtendedTokensExtension
+    extends ThemeExtension<DsExtendedTokensExtension> {
+  const DsExtendedTokensExtension({required this.tokens});
+
+  final DsExtendedTokens tokens;
+
+  @override
+  DsExtendedTokensExtension copyWith({DsExtendedTokens? tokens}) {
+    return DsExtendedTokensExtension(tokens: tokens ?? this.tokens);
+  }
+
+  @override
+  DsExtendedTokensExtension lerp(
+    covariant ThemeExtension<DsExtendedTokensExtension>? other,
+    double t,
+  ) {
+    if (other is! DsExtendedTokensExtension) {
+      return this;
+    }
+    return t < 0.5 ? this : other;
+  }
+}
+
+@immutable
+class DsSemanticColorsExtension
+    extends ThemeExtension<DsSemanticColorsExtension> {
+  const DsSemanticColorsExtension({required this.semantic});
+
+  final ModelSemanticColors semantic;
+
+  @override
+  DsSemanticColorsExtension copyWith({ModelSemanticColors? semantic}) {
+    return DsSemanticColorsExtension(semantic: semantic ?? this.semantic);
+  }
+
+  @override
+  DsSemanticColorsExtension lerp(
+    covariant ThemeExtension<DsSemanticColorsExtension>? other,
+    double t,
+  ) {
+    if (other is! DsSemanticColorsExtension) {
+      return this;
+    }
+    return t < 0.5 ? this : other;
+  }
+}
+
+@immutable
+class DsDataVizPaletteExtension
+    extends ThemeExtension<DsDataVizPaletteExtension> {
+  const DsDataVizPaletteExtension({required this.palette});
+
+  final ModelDataVizPalette palette;
+
+  @override
+  DsDataVizPaletteExtension copyWith({ModelDataVizPalette? palette}) {
+    return DsDataVizPaletteExtension(palette: palette ?? this.palette);
+  }
+
+  @override
+  DsDataVizPaletteExtension lerp(
+    covariant ThemeExtension<DsDataVizPaletteExtension>? other,
+    double t,
+  ) {
+    if (other is! DsDataVizPaletteExtension) {
+      return this;
+    }
+    return t < 0.5 ? this : other;
+  }
+}
+
+extension PragmaDesignSystemThemeX on ThemeData {
+  DsExtendedTokens get dsTokens {
+    return extension<DsExtendedTokensExtension>()?.tokens ??
+        const DsExtendedTokens();
+  }
+
+  ModelSemanticColors get dsSemantic {
+    return extension<DsSemanticColorsExtension>()?.semantic ??
+        ModelSemanticColors.fallbackLight();
+  }
+
+  ModelDataVizPalette get dsDataViz {
+    return extension<DsDataVizPaletteExtension>()?.palette ??
+        ModelDataVizPalette.fallback();
+  }
+}

--- a/lib/src/domain/models/model_ds_component_anatomy.dart
+++ b/lib/src/domain/models/model_ds_component_anatomy.dart
@@ -1,0 +1,603 @@
+import 'package:flutter/foundation.dart';
+
+/// Stable JSON keys for Design System catalog models.
+///
+/// These keys are intended to remain stable across versions to support
+/// export/import and offline catalogs.
+abstract final class ModelDsComponentAnatomyKeys {
+  static const String id = 'id';
+  static const String name = 'name';
+  static const String description = 'description';
+
+  static const String tags = 'tags';
+  static const String status = 'status';
+  static const String platforms = 'platforms';
+
+  /// Use as an asset reference key (recommended) to keep catalog offline-ready.
+  static const String previewAssetKey = 'previewAssetKey';
+
+  /// Optional. External image URL if teams want online docs.
+  static const String previewUrlImage = 'previewUrlImage';
+
+  /// Optional. General documentation URL (e.g. internal wiki, Notion, etc.)
+  static const String urlDetailedInfo = 'urlDetailedInfo';
+
+  /// Optional. Extra links with labels.
+  static const String links = 'links';
+
+  /// Anatomy slots describe the internal parts of a component (label/icon/container).
+  static const String slots = 'slots';
+}
+
+/// Stable JSON keys for a component link entry.
+abstract final class ModelDsComponentLinkKeys {
+  static const String label = 'label';
+  static const String url = 'url';
+}
+
+/// Stable JSON keys for a component anatomy slot.
+abstract final class ModelDsComponentSlotKeys {
+  static const String name = 'name';
+  static const String role = 'role';
+  static const String rules = 'rules';
+  static const String tokensUsed = 'tokensUsed';
+}
+
+/// Catalog status for documentation lifecycle.
+enum ModelDsComponentStatusEnum {
+  draft,
+  stable,
+  deprecated,
+}
+
+/// Supported platforms for catalog filtering.
+enum ModelDsComponentPlatformEnum {
+  android,
+  ios,
+  web,
+  windows,
+  macos,
+  linux,
+}
+
+/// Represents a labeled documentation link.
+///
+/// This model is intentionally minimal:
+/// - `label`: human-readable title (non-empty)
+/// - `url`: a non-empty string (format not enforced)
+///
+/// Throws:
+/// - [FormatException] from [fromJson] when fields are missing or invalid.
+@immutable
+class ModelDsComponentLink {
+  const ModelDsComponentLink({
+    required this.label,
+    required this.url,
+  });
+
+  /// Builds a link from strict JSON.
+  ///
+  /// Expected shape:
+  /// ```json
+  /// {"label": "API docs", "url": "https://..."}
+  /// ```
+  ///
+  /// Throws:
+  /// - [FormatException] if `label` or `url` is missing/empty.
+  factory ModelDsComponentLink.fromJson(Map<String, dynamic> json) {
+    final Object? labelRaw = json[ModelDsComponentLinkKeys.label];
+    final Object? urlRaw = json[ModelDsComponentLinkKeys.url];
+
+    if (labelRaw is! String || labelRaw.trim().isEmpty) {
+      throw const FormatException('Invalid link label');
+    }
+    if (urlRaw is! String || urlRaw.trim().isEmpty) {
+      throw const FormatException('Invalid link url');
+    }
+
+    return ModelDsComponentLink(
+      label: labelRaw,
+      url: urlRaw,
+    );
+  }
+
+  final String label;
+  final String url;
+
+  /// Serializes this instance into JSON compatible with [fromJson].
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        ModelDsComponentLinkKeys.label: label,
+        ModelDsComponentLinkKeys.url: url,
+      };
+
+  void _validate() {
+    if (label.trim().isEmpty) {
+      throw const FormatException('Link label must not be empty');
+    }
+    if (url.trim().isEmpty) {
+      throw const FormatException('Link url must not be empty');
+    }
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    return other is ModelDsComponentLink &&
+        other.label == label &&
+        other.url == url;
+  }
+
+  @override
+  int get hashCode => label.hashCode ^ (url.hashCode * 3);
+}
+
+/// Describes an internal “part” of a component (anatomy slot).
+///
+/// A slot exists to document:
+/// - what the part is (`name`)
+/// - why it exists (`role`)
+/// - how it should behave (`rules`)
+/// - which DS tokens control it (`tokensUsed`)
+///
+/// Throws:
+/// - [FormatException] from [fromJson] when the payload is invalid.
+@immutable
+class ModelDsComponentSlot {
+  const ModelDsComponentSlot({
+    required this.name,
+    required this.role,
+    required this.rules,
+    required this.tokensUsed,
+  });
+
+  /// Builds a slot from strict JSON.
+  ///
+  /// Expected shape:
+  /// ```json
+  /// {
+  ///   "name": "Container",
+  ///   "role": "Defines surface and elevation",
+  ///   "rules": ["Must be tappable", "Supports disabled state"],
+  ///   "tokensUsed": ["borderRadiusLg", "elevationSm"]
+  /// }
+  /// ```
+  ///
+  /// Throws:
+  /// - [FormatException] if any required field is missing/empty.
+  factory ModelDsComponentSlot.fromJson(Map<String, dynamic> json) {
+    final Object? nameRaw = json[ModelDsComponentSlotKeys.name];
+    final Object? roleRaw = json[ModelDsComponentSlotKeys.role];
+    final Object? rulesRaw = json[ModelDsComponentSlotKeys.rules];
+    final Object? tokensRaw = json[ModelDsComponentSlotKeys.tokensUsed];
+
+    if (nameRaw is! String || nameRaw.trim().isEmpty) {
+      throw const FormatException('Invalid slot name');
+    }
+    if (roleRaw is! String || roleRaw.trim().isEmpty) {
+      throw const FormatException('Invalid slot role');
+    }
+
+    final List<String> rules = _readStringListStrict(rulesRaw, 'rules');
+    final List<String> tokens = _readStringListStrict(tokensRaw, 'tokensUsed');
+
+    final ModelDsComponentSlot out = ModelDsComponentSlot(
+      name: nameRaw,
+      role: roleRaw,
+      rules: rules,
+      tokensUsed: tokens,
+    );
+
+    out._validate();
+    return out;
+  }
+
+  /// Slot name (e.g. "Container", "Label", "LeadingIcon", "Spinner").
+  final String name;
+
+  /// Slot role/purpose in UI (short).
+  final String role;
+
+  /// Human-readable rules for this slot (short).
+  final List<String> rules;
+
+  /// Token keys referenced by this slot (e.g. "spacingSm", "borderRadiusLg").
+  final List<String> tokensUsed;
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        ModelDsComponentSlotKeys.name: name,
+        ModelDsComponentSlotKeys.role: role,
+        ModelDsComponentSlotKeys.rules: rules,
+        ModelDsComponentSlotKeys.tokensUsed: tokensUsed,
+      };
+
+  void _validate() {
+    if (name.trim().isEmpty) {
+      throw const FormatException('Slot name must not be empty');
+    }
+    if (role.trim().isEmpty) {
+      throw const FormatException('Slot role must not be empty');
+    }
+
+    if (rules.isEmpty) {
+      throw const FormatException('Slot rules must not be empty');
+    }
+    if (tokensUsed.isEmpty) {
+      throw const FormatException('Slot tokensUsed must not be empty');
+    }
+
+    for (final String r in rules) {
+      if (r.trim().isEmpty) {
+        throw const FormatException('Slot rule must not be empty');
+      }
+    }
+    for (final String t in tokensUsed) {
+      if (t.trim().isEmpty) {
+        throw const FormatException('Slot token must not be empty');
+      }
+    }
+  }
+
+  static List<String> _readStringListStrict(Object? raw, String fieldName) {
+    if (raw is! List<dynamic>) {
+      throw FormatException('Expected list for $fieldName');
+    }
+    final List<String> out = <String>[];
+    for (final dynamic item in raw) {
+      if (item is! String || item.trim().isEmpty) {
+        throw FormatException('Invalid item in $fieldName');
+      }
+      out.add(item);
+    }
+    return out;
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (other is! ModelDsComponentSlot) {
+      return false;
+    }
+    return other.name == name &&
+        other.role == role &&
+        listEquals(other.rules, rules) &&
+        listEquals(other.tokensUsed, tokensUsed);
+  }
+
+  @override
+  int get hashCode {
+    int h = name.hashCode ^ (role.hashCode * 3);
+    for (final String r in rules) {
+      h ^= r.hashCode * 5;
+    }
+    for (final String t in tokensUsed) {
+      h ^= t.hashCode * 7;
+    }
+    return h;
+  }
+}
+
+/// Defines how to document and reconstruct a DS component page in a catalog.
+///
+/// This model is designed to be:
+/// - strict and deterministic (invalid payloads fail fast)
+/// - offline-ready (use [previewAssetKey] instead of URLs if desired)
+///
+/// Functional example:
+/// ```dart
+/// void main() {
+///   final ModelDsComponentAnatomy anatomy = ModelDsComponentAnatomy(
+///     id: 'ds.button',
+///     name: 'Buttons',
+///     description: 'Triggers an action with consistent styling.',
+///     tags: const <String>['action', 'input'],
+///     status: ModelDsComponentStatusEnum.stable,
+///     platforms: const <ModelDsComponentPlatformEnum>[
+///       ModelDsComponentPlatformEnum.android,
+///       ModelDsComponentPlatformEnum.ios,
+///       ModelDsComponentPlatformEnum.web,
+///     ],
+///     slots: const <ModelDsComponentSlot>[
+///       ModelDsComponentSlot(
+///         name: 'Container',
+///         role: 'Surface and shape',
+///         rules: <String>['Uses DS radius tokens'],
+///         tokensUsed: <String>['borderRadius', 'spacingSm'],
+///       ),
+///     ],
+///     links: const <ModelDsComponentLink>[
+///       ModelDsComponentLink(label: 'Guidelines', url: 'https://internal/wiki'),
+///     ],
+///   );
+///
+///   final Map<String, dynamic> json = anatomy.toJson();
+///   final ModelDsComponentAnatomy restored = ModelDsComponentAnatomy.fromJson(json);
+///   assert(anatomy.id == restored.id);
+/// }
+/// ```
+///
+/// Throws:
+/// - [FormatException] from [fromJson] when the payload is invalid.
+@immutable
+class ModelDsComponentAnatomy {
+  const ModelDsComponentAnatomy({
+    required this.id,
+    required this.name,
+    required this.description,
+    required this.tags,
+    required this.status,
+    required this.platforms,
+    required this.slots,
+    this.previewAssetKey,
+    this.previewUrlImage,
+    this.urlDetailedInfo,
+    this.links = const <ModelDsComponentLink>[],
+  });
+
+  /// Strict JSON import.
+  ///
+  /// Required fields:
+  /// - id, name, description: non-empty strings
+  /// - tags: non-empty list of non-empty strings
+  /// - status: one of [ModelDsComponentStatusEnum.name]
+  /// - platforms: non-empty list of [ModelDsComponentPlatformEnum.name]
+  /// - slots: non-empty list of slot maps
+  ///
+  /// Optional fields:
+  /// - previewAssetKey, previewUrlImage, urlDetailedInfo: nullable strings (empty -> null)
+  /// - links: list of link maps (missing/null -> empty)
+  ///
+  /// Throws:
+  /// - [FormatException] if the payload is missing fields or has invalid values.
+  factory ModelDsComponentAnatomy.fromJson(Map<String, dynamic> json) {
+    final Object? idRaw = json[ModelDsComponentAnatomyKeys.id];
+    final Object? nameRaw = json[ModelDsComponentAnatomyKeys.name];
+    final Object? descRaw = json[ModelDsComponentAnatomyKeys.description];
+
+    if (idRaw is! String || idRaw.trim().isEmpty) {
+      throw const FormatException('Invalid id');
+    }
+    if (nameRaw is! String || nameRaw.trim().isEmpty) {
+      throw const FormatException('Invalid name');
+    }
+    if (descRaw is! String || descRaw.trim().isEmpty) {
+      throw const FormatException('Invalid description');
+    }
+
+    final List<String> tags =
+        _readStringListStrict(json[ModelDsComponentAnatomyKeys.tags], 'tags');
+
+    final ModelDsComponentStatusEnum status =
+        _readStatusStrict(json[ModelDsComponentAnatomyKeys.status]);
+
+    final List<ModelDsComponentPlatformEnum> platforms =
+        _readPlatformsStrict(json[ModelDsComponentAnatomyKeys.platforms]);
+
+    final String? previewAssetKey =
+        _readNullableString(json[ModelDsComponentAnatomyKeys.previewAssetKey]);
+    final String? previewUrlImage =
+        _readNullableString(json[ModelDsComponentAnatomyKeys.previewUrlImage]);
+    final String? urlDetailedInfo =
+        _readNullableString(json[ModelDsComponentAnatomyKeys.urlDetailedInfo]);
+
+    final List<ModelDsComponentLink> links = _readLinksStrict(
+      json[ModelDsComponentAnatomyKeys.links],
+    );
+
+    final List<ModelDsComponentSlot> slots = _readSlotsStrict(
+      json[ModelDsComponentAnatomyKeys.slots],
+    );
+
+    final ModelDsComponentAnatomy out = ModelDsComponentAnatomy(
+      id: idRaw,
+      name: nameRaw,
+      description: descRaw,
+      tags: tags,
+      status: status,
+      platforms: platforms,
+      previewAssetKey: previewAssetKey,
+      previewUrlImage: previewUrlImage,
+      urlDetailedInfo: urlDetailedInfo,
+      links: links,
+      slots: slots,
+    );
+
+    out._validate();
+    return out;
+  }
+
+  /// Stable identifier (e.g. "ds.button", "ds.text_field").
+  final String id;
+
+  /// Display name (e.g. "Buttons", "TextField").
+  final String name;
+
+  /// Short description: what it is and when to use.
+  final String description;
+
+  /// Tags for search and grouping.
+  final List<String> tags;
+
+  /// Lifecycle status (draft/stable/deprecated).
+  final ModelDsComponentStatusEnum status;
+
+  /// Supported platforms where this component applies.
+  final List<ModelDsComponentPlatformEnum> platforms;
+
+  /// Optional: asset key to render a preview image offline.
+  final String? previewAssetKey;
+
+  /// Optional: external preview image URL.
+  final String? previewUrlImage;
+
+  /// Optional: detailed documentation URL.
+  final String? urlDetailedInfo;
+
+  /// Extra links.
+  final List<ModelDsComponentLink> links;
+
+  /// Anatomy slots: internal parts and what tokens control them.
+  final List<ModelDsComponentSlot> slots;
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        ModelDsComponentAnatomyKeys.id: id,
+        ModelDsComponentAnatomyKeys.name: name,
+        ModelDsComponentAnatomyKeys.description: description,
+        ModelDsComponentAnatomyKeys.tags: tags,
+        ModelDsComponentAnatomyKeys.status: status.name,
+        ModelDsComponentAnatomyKeys.platforms:
+            platforms.map((ModelDsComponentPlatformEnum e) => e.name).toList(),
+        ModelDsComponentAnatomyKeys.previewAssetKey: previewAssetKey,
+        ModelDsComponentAnatomyKeys.previewUrlImage: previewUrlImage,
+        ModelDsComponentAnatomyKeys.urlDetailedInfo: urlDetailedInfo,
+        ModelDsComponentAnatomyKeys.links:
+            links.map((ModelDsComponentLink e) => e.toJson()).toList(),
+        ModelDsComponentAnatomyKeys.slots:
+            slots.map((ModelDsComponentSlot e) => e.toJson()).toList(),
+      };
+
+  void _validate() {
+    if (id.trim().isEmpty) {
+      throw const FormatException('id must not be empty');
+    }
+    if (name.trim().isEmpty) {
+      throw const FormatException('name must not be empty');
+    }
+    if (description.trim().isEmpty) {
+      throw const FormatException('description must not be empty');
+    }
+
+    if (tags.isEmpty) {
+      throw const FormatException('tags must not be empty');
+    }
+    if (platforms.isEmpty) {
+      throw const FormatException('platforms must not be empty');
+    }
+    if (slots.isEmpty) {
+      throw const FormatException('slots must not be empty');
+    }
+
+    for (final String t in tags) {
+      if (t.trim().isEmpty) {
+        throw const FormatException('tag must not be empty');
+      }
+    }
+
+    for (final ModelDsComponentLink l in links) {
+      l._validate();
+    }
+    for (final ModelDsComponentSlot s in slots) {
+      s._validate();
+    }
+  }
+
+  static List<String> _readStringListStrict(Object? raw, String fieldName) {
+    if (raw is! List<dynamic>) {
+      throw FormatException('Expected list for $fieldName');
+    }
+    final List<String> out = <String>[];
+    for (final dynamic item in raw) {
+      if (item is! String || item.trim().isEmpty) {
+        throw FormatException('Invalid item in $fieldName');
+      }
+      out.add(item);
+    }
+    return out;
+  }
+
+  static String? _readNullableString(Object? raw) {
+    if (raw == null) {
+      return null;
+    }
+    if (raw is! String) {
+      throw const FormatException('Expected string');
+    }
+    final String v = raw.trim();
+    if (v.isEmpty) {
+      return null;
+    }
+    return v;
+  }
+
+  static ModelDsComponentStatusEnum _readStatusStrict(Object? raw) {
+    if (raw is! String || raw.trim().isEmpty) {
+      throw const FormatException('Invalid status');
+    }
+    for (final ModelDsComponentStatusEnum e
+        in ModelDsComponentStatusEnum.values) {
+      if (e.name == raw) {
+        return e;
+      }
+    }
+    throw FormatException('Unknown status: $raw');
+  }
+
+  static List<ModelDsComponentPlatformEnum> _readPlatformsStrict(Object? raw) {
+    if (raw is! List<dynamic>) {
+      throw const FormatException('Expected list for platforms');
+    }
+    final List<ModelDsComponentPlatformEnum> out =
+        <ModelDsComponentPlatformEnum>[];
+    for (final dynamic item in raw) {
+      if (item is! String || item.trim().isEmpty) {
+        throw const FormatException('Invalid platform item');
+      }
+      final ModelDsComponentPlatformEnum? match = _platformFromName(item);
+      if (match == null) {
+        throw FormatException('Unknown platform: $item');
+      }
+      out.add(match);
+    }
+    if (out.isEmpty) {
+      throw const FormatException('platforms must not be empty');
+    }
+    return out;
+  }
+
+  static ModelDsComponentPlatformEnum? _platformFromName(String name) {
+    for (final ModelDsComponentPlatformEnum e
+        in ModelDsComponentPlatformEnum.values) {
+      if (e.name == name) {
+        return e;
+      }
+    }
+    return null;
+  }
+
+  static List<ModelDsComponentLink> _readLinksStrict(Object? raw) {
+    if (raw == null) {
+      return <ModelDsComponentLink>[];
+    }
+    if (raw is! List<dynamic>) {
+      throw const FormatException('Expected list for links');
+    }
+    final List<ModelDsComponentLink> out = <ModelDsComponentLink>[];
+    for (final dynamic item in raw) {
+      if (item is! Map<String, dynamic>) {
+        throw const FormatException('Invalid link entry');
+      }
+      out.add(ModelDsComponentLink.fromJson(item));
+    }
+    return out;
+  }
+
+  static List<ModelDsComponentSlot> _readSlotsStrict(Object? raw) {
+    if (raw is! List<dynamic>) {
+      throw const FormatException('Expected list for slots');
+    }
+    final List<ModelDsComponentSlot> out = <ModelDsComponentSlot>[];
+    for (final dynamic item in raw) {
+      if (item is! Map<String, dynamic>) {
+        throw const FormatException('Invalid slot entry');
+      }
+      out.add(ModelDsComponentSlot.fromJson(item));
+    }
+    if (out.isEmpty) {
+      throw const FormatException('slots must not be empty');
+    }
+    return out;
+  }
+}

--- a/lib/src/domain/models/model_ds_dataviz_palette.dart
+++ b/lib/src/domain/models/model_ds_dataviz_palette.dart
@@ -1,0 +1,238 @@
+import 'package:flutter/material.dart';
+
+import '../../tokens/pragma_color_tokens.dart';
+
+/// JSON keys for [ModelDataVizPalette].
+///
+/// Notes:
+/// - Keys are intentionally stable to support export/import.
+/// - The JSON payload is strict: both entries must exist and be lists of ARGB ints.
+abstract final class ModelDataVizPaletteKeys {
+  static const String categorical = 'categorical';
+  static const String sequential = 'sequential';
+
+  static const List<String> all = <String>[
+    categorical,
+    sequential,
+  ];
+}
+
+/// Defines a data visualization palette with categorical and sequential colors.
+///
+/// - [categorical] is intended for discrete series (e.g., line/bar series).
+/// - [sequential] is intended for continuous values mapped to a gradient-like scale.
+///
+/// The model is JSON-safe via [toJson] and [fromJson].
+///
+/// Validation rules:
+/// - `categorical` must not be empty.
+/// - `sequential` must have at least 2 colors.
+///
+/// Functional example:
+/// ```dart
+/// import 'package:flutter/material.dart';
+///
+/// void main() {
+///   final ModelDataVizPalette palette = ModelDataVizPalette.fallback();
+///
+///   final Color series0 = palette.categoricalAt(0);
+///   final Color series11 = palette.categoricalAt(11); // wraps around
+///
+///   final Color low = palette.sequentialAt(0.0);
+///   final Color mid = palette.sequentialAt(0.5);
+///   final Color high = palette.sequentialAt(1.0);
+///
+///   print(series0);
+///   print(series11);
+///   print(low);
+///   print(mid);
+///   print(high);
+/// }
+/// ```
+///
+/// Throws:
+/// - [RangeError] if validation fails.
+/// - [FormatException] from [fromJson] when the payload shape is invalid.
+@immutable
+class ModelDataVizPalette {
+  const ModelDataVizPalette({
+    required this.categorical,
+    required this.sequential,
+  });
+
+  /// Returns a recommended default palette.
+  ///
+  /// Contains:
+  /// - 10 categorical colors (discrete series)
+  /// - 6 sequential steps (gradient-like)
+  ///
+  /// Palette mapped to the currently available Foundation color tokens
+  /// in this library.
+  ///
+  /// Throws:
+  /// - [RangeError] if validation fails (should not happen).
+  factory ModelDataVizPalette.fallback() {
+    const List<Color> categorical = <Color>[
+      PragmaColorTokens.primaryPurple500,
+      PragmaColorTokens.secondaryFuchsia700,
+      PragmaColorTokens.secondaryPurple500,
+      PragmaColorTokens.primaryIndigo700,
+      PragmaColorTokens.primaryIndigo900,
+      PragmaColorTokens.tertiaryYellow500,
+      PragmaColorTokens.success500,
+      PragmaColorTokens.warning500,
+      PragmaColorTokens.error500,
+      PragmaColorTokens.neutralGray500,
+    ];
+
+    const List<Color> sequential = <Color>[
+      PragmaColorTokens.primaryPurple50,
+      PragmaColorTokens.primaryPurple300,
+      PragmaColorTokens.primaryPurple500,
+      PragmaColorTokens.secondaryPurple500,
+      PragmaColorTokens.primaryPurple700,
+      PragmaColorTokens.primaryPurple900,
+    ];
+
+    return const ModelDataVizPalette(
+      categorical: categorical,
+      sequential: sequential,
+    ).._validate();
+  }
+
+  /// Builds a palette from a strict JSON payload.
+  ///
+  /// Both keys in [ModelDataVizPaletteKeys.all] must exist.
+  /// Each entry must be a list of ARGB 32-bit integers.
+  ///
+  /// Throws:
+  /// - [FormatException] if a required key is missing or not a list.
+  /// - [RangeError] if validation fails.
+  factory ModelDataVizPalette.fromJson(Map<String, dynamic> json) {
+    for (final String key in ModelDataVizPaletteKeys.all) {
+      if (!json.containsKey(key)) {
+        throw FormatException('Missing key: $key');
+      }
+    }
+
+    List<Color> readColors(String key) {
+      final Object? raw = json[key];
+      if (raw is! List<dynamic>) {
+        throw FormatException('Expected list for $key');
+      }
+      return raw
+          .map((dynamic e) => Color(_toInteger(e)))
+          .toList(growable: false);
+    }
+
+    final ModelDataVizPalette out = ModelDataVizPalette(
+      categorical: readColors(ModelDataVizPaletteKeys.categorical),
+      sequential: readColors(ModelDataVizPaletteKeys.sequential),
+    );
+
+    out._validate();
+    return out;
+  }
+
+  /// The categorical palette used for discrete series.
+  final List<Color> categorical;
+
+  /// The sequential palette used for continuous values (0..1).
+  final List<Color> sequential;
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        ModelDataVizPaletteKeys.categorical:
+            categorical.map((Color c) => c.toARGB32()).toList(growable: false),
+        ModelDataVizPaletteKeys.sequential:
+            sequential.map((Color c) => c.toARGB32()).toList(growable: false),
+      };
+
+  void _validate() {
+    if (categorical.isEmpty) {
+      throw RangeError('categorical palette must not be empty');
+    }
+    if (sequential.length < 2) {
+      throw RangeError('sequential palette must have at least 2 colors');
+    }
+  }
+
+  Color categoricalAt(int i) => categorical[i % categorical.length];
+
+  /// t in 0..1 mapped across sequential steps.
+  Color sequentialAt(double t) {
+    if (t <= 0.0) {
+      return sequential.first;
+    }
+    if (t >= 1.0) {
+      return sequential.last;
+    }
+
+    final double pos = t * (sequential.length - 1);
+    final int idx = pos.floor();
+    final int next = (idx + 1).clamp(0, sequential.length - 1);
+    final double localT = pos - idx;
+
+    return Color.lerp(sequential[idx], sequential[next], localT) ??
+        sequential[idx];
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (other.runtimeType != runtimeType) {
+      return false;
+    }
+    if (other is! ModelDataVizPalette) {
+      return false;
+    }
+
+    // Equality by content (simple + deterministic)
+    if (categorical.length != other.categorical.length) {
+      return false;
+    }
+    if (sequential.length != other.sequential.length) {
+      return false;
+    }
+
+    for (int i = 0; i < categorical.length; i++) {
+      if (categorical[i] != other.categorical[i]) {
+        return false;
+      }
+    }
+    for (int i = 0; i < sequential.length; i++) {
+      if (sequential[i] != other.sequential[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  @override
+  int get hashCode {
+    int h = 17;
+    for (final Color c in categorical) {
+      h = 37 * h ^ c.toARGB32().hashCode;
+    }
+    for (final Color c in sequential) {
+      h = 41 * h ^ c.toARGB32().hashCode;
+    }
+    return h;
+  }
+
+  static int _toInteger(dynamic value) {
+    if (value is int) {
+      return value;
+    }
+    if (value is num) {
+      return value.round();
+    }
+    if (value is String) {
+      return int.tryParse(value.trim()) ??
+          double.tryParse(value.trim())?.round() ??
+          0;
+    }
+    return 0;
+  }
+}

--- a/lib/src/domain/models/model_ds_extended_tokens.dart
+++ b/lib/src/domain/models/model_ds_extended_tokens.dart
@@ -1,0 +1,786 @@
+import 'package:flutter/foundation.dart';
+
+/// Adapted from `jocaaguraarchetype`.
+///
+/// Thanks to the `grupo-jocaagura/jocaaguraarchetype` team for the original
+/// model and base structure:
+/// https://github.com/grupo-jocaagura/jocaaguraarchetype/blob/develop/lib/domain/models/model_ds_extended_tokens.dart
+/// Defines stable JSON keys for [DsExtendedTokens].
+///
+/// This is a centralized registry of keys to ensure:
+/// - Export/import consistency.
+/// - Validation of required keys during [DsExtendedTokens.fromJson].
+///
+/// The [all] list contains every key that must exist in a valid JSON payload.
+///
+/// Notes:
+/// - Keys are intentionally stable; avoid renaming.
+/// - Adding a new key is a breaking change for strict JSON import.
+abstract class DsExtendedTokensKeys {
+  static const String spacingXs = 'spacingXs';
+  static const String spacingSm = 'spacingSm';
+  static const String spacing = 'spacing';
+  static const String spacingLg = 'spacingLg';
+  static const String spacingXl = 'spacingXl';
+  static const String spacingXXl = 'spacingXXl';
+
+  static const String borderRadiusXs = 'borderRadiusXs';
+  static const String borderRadiusSm = 'borderRadiusSm';
+  static const String borderRadius = 'borderRadius';
+  static const String borderRadiusLg = 'borderRadiusLg';
+  static const String borderRadiusXl = 'borderRadiusXl';
+  static const String borderRadiusXXl = 'borderRadiusXXl';
+
+  static const String elevationXs = 'elevationXs';
+  static const String elevationSm = 'elevationSm';
+  static const String elevation = 'elevation';
+  static const String elevationLg = 'elevationLg';
+  static const String elevationXl = 'elevationXl';
+  static const String elevationXXl = 'elevationXXl';
+
+  /// Values intended to be used with `Color.withOpacity(x)` or `withAlpha(...)` conversions.
+  /// Range: 0..1.
+  static const String withAlphaXs = 'withAlphaXs';
+  static const String withAlphaSm = 'withAlphaSm';
+  static const String withAlpha = 'withAlpha';
+  static const String withAlphaLg = 'withAlphaLg';
+  static const String withAlphaXl = 'withAlphaXl';
+  static const String withAlphaXXl = 'withAlphaXXl';
+
+  static const String animationDurationShort = 'animationDurationShort';
+  static const String animationDuration = 'animationDuration';
+  static const String animationDurationLong = 'animationDurationLong';
+
+  static const List<String> all = <String>[
+    spacingXs,
+    spacingSm,
+    spacing,
+    spacingLg,
+    spacingXl,
+    spacingXXl,
+    borderRadiusXs,
+    borderRadiusSm,
+    borderRadius,
+    borderRadiusLg,
+    borderRadiusXl,
+    borderRadiusXXl,
+    elevationXs,
+    elevationSm,
+    elevation,
+    elevationLg,
+    elevationXl,
+    elevationXXl,
+    withAlphaXs,
+    withAlphaSm,
+    withAlpha,
+    withAlphaLg,
+    withAlphaXl,
+    withAlphaXXl,
+    animationDurationShort,
+    animationDuration,
+    animationDurationLong,
+  ];
+}
+
+/// Represents a set of extended Design System tokens.
+///
+/// This model groups commonly needed numeric tokens:
+/// - Spacing scale (xs..xxl)
+/// - Border radius scale (xs..xxl)
+/// - Elevation scale (xs..xxl)
+/// - Alpha scale for color opacity (xs..xxl) in the 0..1 range
+/// - Animation durations (short/regular/long)
+///
+/// The instance is immutable and self-validating. Any constructor that builds
+/// an instance will call an internal validation step.
+///
+/// Functional example:
+/// ```dart
+/// void main() {
+///   final DsExtendedTokens tokens = DsExtendedTokens.fromFactor(
+///     spacingFactor: 2.0,
+///     initialSpacing: 4.0,
+///     borderRadiusFactor: 2.0,
+///     initialBorderRadius: 2.0,
+///     elevationFactor: 2.0,
+///     initialElevation: 1.0,
+///     withAlphaFactor: 1.5,
+///     initialWithAlpha: 0.04,
+///     animationDurationFactor: 3,
+///     initialAnimationDuration: 100.0,
+///   );
+///
+///   final Map<String, dynamic> json = tokens.toJson();
+///   final DsExtendedTokens restored = DsExtendedTokens.fromJson(json);
+///
+///   // Round-trip safety (should be true for the same values).
+///   assert(tokens == restored);
+///   print(restored.spacing); // e.g. 16.0
+/// }
+/// ```
+///
+/// Contracts:
+/// - Spacing, radius and elevation values must be finite and >= 0.
+/// - `withAlpha*` values must be finite and within 0..1.
+/// - Each scale must be ascending (xs <= sm <= ... <= xxl).
+/// - Durations must be >= 0 and ascending:
+///   short <= regular <= long.
+///
+/// Throws:
+/// - [RangeError] if any contract is violated.
+/// - [FormatException] from [fromJson] if any required key is missing.
+@immutable
+class DsExtendedTokens {
+  const DsExtendedTokens({
+    this.spacingXs = 4.0,
+    this.spacingSm = 8.0,
+    this.spacing = 16.0,
+    this.spacingLg = 24.0,
+    this.spacingXl = 32.0,
+    this.spacingXXl = 64.0,
+    this.borderRadiusXs = 2.0,
+    this.borderRadiusSm = 4.0,
+    this.borderRadius = 8.0,
+    this.borderRadiusLg = 12.0,
+    this.borderRadiusXl = 16.0,
+    this.borderRadiusXXl = 24.0,
+    this.elevationXs = 0.0,
+    this.elevationSm = 1.0,
+    this.elevation = 3.0,
+    this.elevationLg = 6.0,
+    this.elevationXl = 9.0,
+    this.elevationXXl = 12.0,
+    this.withAlphaXs = 0.04,
+    this.withAlphaSm = 0.12,
+    this.withAlpha = 0.16,
+    this.withAlphaLg = 0.24,
+    this.withAlphaXl = 0.32,
+    this.withAlphaXXl = 0.40,
+    this.animationDurationShort = const Duration(milliseconds: 100),
+    this.animationDuration = const Duration(milliseconds: 300),
+    this.animationDurationLong = const Duration(milliseconds: 800),
+  });
+
+  /// Builds a token set using geometric progression factors.
+  ///
+  /// Notes:
+  /// - Spacing / radius / elevation grow by multiplying the previous step by a factor.
+  /// - `withAlpha*` grows upwards but is clamped into 0..1.
+  /// - Durations are derived from `initialAnimationDuration` and `animationDurationFactor`.
+  ///
+  /// Parameters:
+  /// - `spacingFactor`, `borderRadiusFactor`, `elevationFactor`:
+  ///   Multipliers for each scale.
+  /// - `initialSpacing`, `initialBorderRadius`, `initialElevation`:
+  ///   The base value for the `*Xs` token.
+  /// - `withAlphaFactor`:
+  ///   Multiplier used for alpha tokens. Values are clamped into 0..1.
+  /// - `initialWithAlpha`:
+  ///   Base alpha used for `withAlphaXs` (0..1).
+  /// - `animationDurationFactor`:
+  ///   Multiplier applied to durations. `long = base * factor^2`.
+  /// - `initialAnimationDuration`:
+  ///   Base duration (milliseconds) used for `animationDurationShort`.
+  ///
+  /// Throws:
+  /// - [RangeError] if the generated values violate the contracts
+  ///   (non-finite values, negatives, non-ascending scales, invalid alpha range, etc.).
+  factory DsExtendedTokens.fromFactor({
+    double spacingFactor = 2.0,
+    double initialSpacing = 4.0,
+    double borderRadiusFactor = 2.0,
+    double initialBorderRadius = 2.0,
+    double elevationFactor = 2.0,
+    double initialElevation = 1.0,
+
+    /// ⚠️ `withAlpha` grows upward (0..1), so factor should be > 1 (e.g. 1.5 or 1.25).
+    double withAlphaFactor = 1.5,
+    double initialWithAlpha = 0.04,
+    int animationDurationFactor = 3,
+    double initialAnimationDuration = 100.0,
+  }) {
+    double pNumber(double base, double factor, int exp) {
+      double out = base;
+      for (int i = 0; i < exp; i++) {
+        out *= factor;
+      }
+      return out;
+    }
+
+    int ms(double x) => x.round();
+
+    final DsExtendedTokens out = DsExtendedTokens(
+      spacingXs: initialSpacing,
+      spacingSm: pNumber(initialSpacing, spacingFactor, 1),
+      spacing: pNumber(initialSpacing, spacingFactor, 2),
+      spacingLg: pNumber(initialSpacing, spacingFactor, 3),
+      spacingXl: pNumber(initialSpacing, spacingFactor, 4),
+      spacingXXl: pNumber(initialSpacing, spacingFactor, 5),
+      borderRadiusXs: initialBorderRadius,
+      borderRadiusSm: pNumber(initialBorderRadius, borderRadiusFactor, 1),
+      borderRadius: pNumber(initialBorderRadius, borderRadiusFactor, 2),
+      borderRadiusLg: pNumber(initialBorderRadius, borderRadiusFactor, 3),
+      borderRadiusXl: pNumber(initialBorderRadius, borderRadiusFactor, 4),
+      borderRadiusXXl: pNumber(initialBorderRadius, borderRadiusFactor, 5),
+      elevationXs: initialElevation,
+      elevationSm: pNumber(initialElevation, elevationFactor, 1),
+      elevation: pNumber(initialElevation, elevationFactor, 2),
+      elevationLg: pNumber(initialElevation, elevationFactor, 3),
+      elevationXl: pNumber(initialElevation, elevationFactor, 4),
+      elevationXXl: pNumber(initialElevation, elevationFactor, 5),
+      withAlphaXs: initialWithAlpha,
+      withAlphaSm: _toDouble(
+        pNumber(initialWithAlpha, withAlphaFactor, 1).clamp(0.0, 1.0),
+      ),
+      withAlpha: _toDouble(
+        pNumber(initialWithAlpha, withAlphaFactor, 2).clamp(0.0, 1.0),
+      ),
+      withAlphaLg: _toDouble(
+        pNumber(initialWithAlpha, withAlphaFactor, 3).clamp(0.0, 1.0),
+      ),
+      withAlphaXl: _toDouble(
+        pNumber(initialWithAlpha, withAlphaFactor, 4).clamp(0.0, 1.0),
+      ),
+      withAlphaXXl: _toDouble(
+        pNumber(initialWithAlpha, withAlphaFactor, 5).clamp(0.0, 1.0),
+      ),
+      animationDurationShort:
+          Duration(milliseconds: ms(initialAnimationDuration)),
+      animationDuration: Duration(
+        milliseconds: ms(initialAnimationDuration * animationDurationFactor),
+      ),
+      animationDurationLong: Duration(
+        milliseconds: ms(
+          initialAnimationDuration *
+              animationDurationFactor *
+              animationDurationFactor,
+        ),
+      ),
+    );
+
+    out._validate();
+    return out;
+  }
+
+  /// Builds a token set from a JSON map.
+  ///
+  /// This parser is strict: all keys from [DsExtendedTokensKeys.all]
+  /// must be present, otherwise a [FormatException] is thrown.
+  ///
+  /// Throws:
+  /// - [FormatException] if a required key is missing.
+  /// - [RangeError] if any parsed value violates the contracts.
+  factory DsExtendedTokens.fromJson(Map<String, dynamic> json) {
+    for (final String key in DsExtendedTokensKeys.all) {
+      if (!json.containsKey(key)) {
+        throw FormatException('Missing key: $key');
+      }
+    }
+
+    double doubleNumber(String key) => _toDouble(json[key]);
+    int integerNumber(String key) => _toInteger(json[key]);
+
+    final DsExtendedTokens out = DsExtendedTokens(
+      spacingXs: doubleNumber(DsExtendedTokensKeys.spacingXs),
+      spacingSm: doubleNumber(DsExtendedTokensKeys.spacingSm),
+      spacing: doubleNumber(DsExtendedTokensKeys.spacing),
+      spacingLg: doubleNumber(DsExtendedTokensKeys.spacingLg),
+      spacingXl: doubleNumber(DsExtendedTokensKeys.spacingXl),
+      spacingXXl: doubleNumber(DsExtendedTokensKeys.spacingXXl),
+      borderRadiusXs: doubleNumber(DsExtendedTokensKeys.borderRadiusXs),
+      borderRadiusSm: doubleNumber(DsExtendedTokensKeys.borderRadiusSm),
+      borderRadius: doubleNumber(DsExtendedTokensKeys.borderRadius),
+      borderRadiusLg: doubleNumber(DsExtendedTokensKeys.borderRadiusLg),
+      borderRadiusXl: doubleNumber(DsExtendedTokensKeys.borderRadiusXl),
+      borderRadiusXXl: doubleNumber(DsExtendedTokensKeys.borderRadiusXXl),
+      elevationXs: doubleNumber(DsExtendedTokensKeys.elevationXs),
+      elevationSm: doubleNumber(DsExtendedTokensKeys.elevationSm),
+      elevation: doubleNumber(DsExtendedTokensKeys.elevation),
+      elevationLg: doubleNumber(DsExtendedTokensKeys.elevationLg),
+      elevationXl: doubleNumber(DsExtendedTokensKeys.elevationXl),
+      elevationXXl: doubleNumber(DsExtendedTokensKeys.elevationXXl),
+      withAlphaXs: doubleNumber(DsExtendedTokensKeys.withAlphaXs),
+      withAlphaSm: doubleNumber(DsExtendedTokensKeys.withAlphaSm),
+      withAlpha: doubleNumber(DsExtendedTokensKeys.withAlpha),
+      withAlphaLg: doubleNumber(DsExtendedTokensKeys.withAlphaLg),
+      withAlphaXl: doubleNumber(DsExtendedTokensKeys.withAlphaXl),
+      withAlphaXXl: doubleNumber(DsExtendedTokensKeys.withAlphaXXl),
+      animationDurationShort: Duration(
+        milliseconds:
+            integerNumber(DsExtendedTokensKeys.animationDurationShort),
+      ),
+      animationDuration: Duration(
+        milliseconds: integerNumber(DsExtendedTokensKeys.animationDuration),
+      ),
+      animationDurationLong: Duration(
+        milliseconds: integerNumber(DsExtendedTokensKeys.animationDurationLong),
+      ),
+    );
+
+    out._validate();
+    return out;
+  }
+
+  final double spacingXs;
+  final double spacingSm;
+  final double spacing;
+  final double spacingLg;
+  final double spacingXl;
+  final double spacingXXl;
+
+  final double borderRadiusXs;
+  final double borderRadiusSm;
+  final double borderRadius;
+  final double borderRadiusLg;
+  final double borderRadiusXl;
+  final double borderRadiusXXl;
+
+  final double elevationXs;
+  final double elevationSm;
+  final double elevation;
+  final double elevationLg;
+  final double elevationXl;
+  final double elevationXXl;
+
+  /// Intended for use with `Color.withOpacity(x)` (0..1).
+  final double withAlphaXs;
+  final double withAlphaSm;
+  final double withAlpha;
+  final double withAlphaLg;
+  final double withAlphaXl;
+  final double withAlphaXXl;
+
+  final Duration animationDurationShort;
+  final Duration animationDuration;
+  final Duration animationDurationLong;
+
+  /// Returns a new instance with the provided overrides.
+  ///
+  /// Optimization: if every parameter is `null`, returns `this`.
+  ///
+  /// Throws:
+  /// - [RangeError] if the resulting instance violates the contracts.
+  DsExtendedTokens copyWith({
+    double? spacingXs,
+    double? spacingSm,
+    double? spacing,
+    double? spacingLg,
+    double? spacingXl,
+    double? spacingXXl,
+    double? borderRadiusXs,
+    double? borderRadiusSm,
+    double? borderRadius,
+    double? borderRadiusLg,
+    double? borderRadiusXl,
+    double? borderRadiusXXl,
+    double? elevationXs,
+    double? elevationSm,
+    double? elevation,
+    double? elevationLg,
+    double? elevationXl,
+    double? elevationXXl,
+    double? withAlphaXs,
+    double? withAlphaSm,
+    double? withAlpha,
+    double? withAlphaLg,
+    double? withAlphaXl,
+    double? withAlphaXXl,
+    Duration? animationDurationShort,
+    Duration? animationDuration,
+    Duration? animationDurationLong,
+  }) {
+    if (spacingXs == null &&
+        spacingSm == null &&
+        spacing == null &&
+        spacingLg == null &&
+        spacingXl == null &&
+        spacingXXl == null &&
+        borderRadiusXs == null &&
+        borderRadiusSm == null &&
+        borderRadius == null &&
+        borderRadiusLg == null &&
+        borderRadiusXl == null &&
+        borderRadiusXXl == null &&
+        elevationXs == null &&
+        elevationSm == null &&
+        elevation == null &&
+        elevationLg == null &&
+        elevationXl == null &&
+        elevationXXl == null &&
+        withAlphaXs == null &&
+        withAlphaSm == null &&
+        withAlpha == null &&
+        withAlphaLg == null &&
+        withAlphaXl == null &&
+        withAlphaXXl == null &&
+        animationDurationShort == null &&
+        animationDuration == null &&
+        animationDurationLong == null) {
+      return this;
+    }
+
+    final DsExtendedTokens out = DsExtendedTokens(
+      spacingXs: spacingXs ?? this.spacingXs,
+      spacingSm: spacingSm ?? this.spacingSm,
+      spacing: spacing ?? this.spacing,
+      spacingLg: spacingLg ?? this.spacingLg,
+      spacingXl: spacingXl ?? this.spacingXl,
+      spacingXXl: spacingXXl ?? this.spacingXXl,
+      borderRadiusXs: borderRadiusXs ?? this.borderRadiusXs,
+      borderRadiusSm: borderRadiusSm ?? this.borderRadiusSm,
+      borderRadius: borderRadius ?? this.borderRadius,
+      borderRadiusLg: borderRadiusLg ?? this.borderRadiusLg,
+      borderRadiusXl: borderRadiusXl ?? this.borderRadiusXl,
+      borderRadiusXXl: borderRadiusXXl ?? this.borderRadiusXXl,
+      elevationXs: elevationXs ?? this.elevationXs,
+      elevationSm: elevationSm ?? this.elevationSm,
+      elevation: elevation ?? this.elevation,
+      elevationLg: elevationLg ?? this.elevationLg,
+      elevationXl: elevationXl ?? this.elevationXl,
+      elevationXXl: elevationXXl ?? this.elevationXXl,
+      withAlphaXs: withAlphaXs ?? this.withAlphaXs,
+      withAlphaSm: withAlphaSm ?? this.withAlphaSm,
+      withAlpha: withAlpha ?? this.withAlpha,
+      withAlphaLg: withAlphaLg ?? this.withAlphaLg,
+      withAlphaXl: withAlphaXl ?? this.withAlphaXl,
+      withAlphaXXl: withAlphaXXl ?? this.withAlphaXXl,
+      animationDurationShort:
+          animationDurationShort ?? this.animationDurationShort,
+      animationDuration: animationDuration ?? this.animationDuration,
+      animationDurationLong:
+          animationDurationLong ?? this.animationDurationLong,
+    );
+
+    out._validate();
+    return out;
+  }
+
+  /// Returns a JSON representation compatible with [fromJson].
+  ///
+  /// Durations are serialized as milliseconds (`int`).
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      DsExtendedTokensKeys.spacingXs: spacingXs,
+      DsExtendedTokensKeys.spacingSm: spacingSm,
+      DsExtendedTokensKeys.spacing: spacing,
+      DsExtendedTokensKeys.spacingLg: spacingLg,
+      DsExtendedTokensKeys.spacingXl: spacingXl,
+      DsExtendedTokensKeys.spacingXXl: spacingXXl,
+      DsExtendedTokensKeys.borderRadiusXs: borderRadiusXs,
+      DsExtendedTokensKeys.borderRadiusSm: borderRadiusSm,
+      DsExtendedTokensKeys.borderRadius: borderRadius,
+      DsExtendedTokensKeys.borderRadiusLg: borderRadiusLg,
+      DsExtendedTokensKeys.borderRadiusXl: borderRadiusXl,
+      DsExtendedTokensKeys.borderRadiusXXl: borderRadiusXXl,
+      DsExtendedTokensKeys.elevationXs: elevationXs,
+      DsExtendedTokensKeys.elevationSm: elevationSm,
+      DsExtendedTokensKeys.elevation: elevation,
+      DsExtendedTokensKeys.elevationLg: elevationLg,
+      DsExtendedTokensKeys.elevationXl: elevationXl,
+      DsExtendedTokensKeys.elevationXXl: elevationXXl,
+      DsExtendedTokensKeys.withAlphaXs: withAlphaXs,
+      DsExtendedTokensKeys.withAlphaSm: withAlphaSm,
+      DsExtendedTokensKeys.withAlpha: withAlpha,
+      DsExtendedTokensKeys.withAlphaLg: withAlphaLg,
+      DsExtendedTokensKeys.withAlphaXl: withAlphaXl,
+      DsExtendedTokensKeys.withAlphaXXl: withAlphaXXl,
+      DsExtendedTokensKeys.animationDurationShort:
+          animationDurationShort.inMilliseconds,
+      DsExtendedTokensKeys.animationDuration: animationDuration.inMilliseconds,
+      DsExtendedTokensKeys.animationDurationLong:
+          animationDurationLong.inMilliseconds,
+    };
+  }
+
+  static double _toDouble(dynamic value) {
+    if (value is double) {
+      return value;
+    }
+    if (value is num) {
+      return value.toDouble();
+    }
+    if (value is String) {
+      return double.tryParse(value.trim()) ?? 0.0;
+    }
+    return 0.0;
+  }
+
+  static int _toInteger(dynamic value) {
+    if (value is int) {
+      return value;
+    }
+    if (value is num) {
+      return value.round();
+    }
+    if (value is String) {
+      return int.tryParse(value.trim()) ??
+          double.tryParse(value.trim())?.round() ??
+          0;
+    }
+    return 0;
+  }
+
+  void _validate() {
+    void nonNegative(double v, String name) {
+      if (v.isNaN || !v.isFinite) {
+        throw RangeError('$name must be finite. Got $v');
+      }
+      if (v < 0) {
+        throw RangeError('$name must be >= 0. Got $v');
+      }
+    }
+
+    void unit(double v, String name) {
+      if (v.isNaN || !v.isFinite) {
+        throw RangeError('$name must be finite. Got $v');
+      }
+      if (v < 0.0 || v > 1.0) {
+        throw RangeError('$name must be within 0..1. Got $v');
+      }
+    }
+
+    void ascending(double a, double b, String aName, String bName) {
+      if (a > b) {
+        throw RangeError('$aName must be <= $bName. Got $a > $b');
+      }
+    }
+
+    nonNegative(spacingXs, DsExtendedTokensKeys.spacingXs);
+    nonNegative(spacingSm, DsExtendedTokensKeys.spacingSm);
+    nonNegative(spacing, DsExtendedTokensKeys.spacing);
+    nonNegative(spacingLg, DsExtendedTokensKeys.spacingLg);
+    nonNegative(spacingXl, DsExtendedTokensKeys.spacingXl);
+    nonNegative(spacingXXl, DsExtendedTokensKeys.spacingXXl);
+
+    ascending(
+      spacingXs,
+      spacingSm,
+      DsExtendedTokensKeys.spacingXs,
+      DsExtendedTokensKeys.spacingSm,
+    );
+    ascending(
+      spacingSm,
+      spacing,
+      DsExtendedTokensKeys.spacingSm,
+      DsExtendedTokensKeys.spacing,
+    );
+    ascending(
+      spacing,
+      spacingLg,
+      DsExtendedTokensKeys.spacing,
+      DsExtendedTokensKeys.spacingLg,
+    );
+    ascending(
+      spacingLg,
+      spacingXl,
+      DsExtendedTokensKeys.spacingLg,
+      DsExtendedTokensKeys.spacingXl,
+    );
+    ascending(
+      spacingXl,
+      spacingXXl,
+      DsExtendedTokensKeys.spacingXl,
+      DsExtendedTokensKeys.spacingXXl,
+    );
+
+    nonNegative(borderRadiusXs, DsExtendedTokensKeys.borderRadiusXs);
+    nonNegative(borderRadiusSm, DsExtendedTokensKeys.borderRadiusSm);
+    nonNegative(borderRadius, DsExtendedTokensKeys.borderRadius);
+    nonNegative(borderRadiusLg, DsExtendedTokensKeys.borderRadiusLg);
+    nonNegative(borderRadiusXl, DsExtendedTokensKeys.borderRadiusXl);
+    nonNegative(borderRadiusXXl, DsExtendedTokensKeys.borderRadiusXXl);
+
+    ascending(
+      borderRadiusXs,
+      borderRadiusSm,
+      DsExtendedTokensKeys.borderRadiusXs,
+      DsExtendedTokensKeys.borderRadiusSm,
+    );
+    ascending(
+      borderRadiusSm,
+      borderRadius,
+      DsExtendedTokensKeys.borderRadiusSm,
+      DsExtendedTokensKeys.borderRadius,
+    );
+    ascending(
+      borderRadius,
+      borderRadiusLg,
+      DsExtendedTokensKeys.borderRadius,
+      DsExtendedTokensKeys.borderRadiusLg,
+    );
+    ascending(
+      borderRadiusLg,
+      borderRadiusXl,
+      DsExtendedTokensKeys.borderRadiusLg,
+      DsExtendedTokensKeys.borderRadiusXl,
+    );
+    ascending(
+      borderRadiusXl,
+      borderRadiusXXl,
+      DsExtendedTokensKeys.borderRadiusXl,
+      DsExtendedTokensKeys.borderRadiusXXl,
+    );
+
+    nonNegative(elevationXs, DsExtendedTokensKeys.elevationXs);
+    nonNegative(elevationSm, DsExtendedTokensKeys.elevationSm);
+    nonNegative(elevation, DsExtendedTokensKeys.elevation);
+    nonNegative(elevationLg, DsExtendedTokensKeys.elevationLg);
+    nonNegative(elevationXl, DsExtendedTokensKeys.elevationXl);
+    nonNegative(elevationXXl, DsExtendedTokensKeys.elevationXXl);
+
+    ascending(
+      elevationXs,
+      elevationSm,
+      DsExtendedTokensKeys.elevationXs,
+      DsExtendedTokensKeys.elevationSm,
+    );
+    ascending(
+      elevationSm,
+      elevation,
+      DsExtendedTokensKeys.elevationSm,
+      DsExtendedTokensKeys.elevation,
+    );
+    ascending(
+      elevation,
+      elevationLg,
+      DsExtendedTokensKeys.elevation,
+      DsExtendedTokensKeys.elevationLg,
+    );
+    ascending(
+      elevationLg,
+      elevationXl,
+      DsExtendedTokensKeys.elevationLg,
+      DsExtendedTokensKeys.elevationXl,
+    );
+    ascending(
+      elevationXl,
+      elevationXXl,
+      DsExtendedTokensKeys.elevationXl,
+      DsExtendedTokensKeys.elevationXXl,
+    );
+
+    unit(withAlphaXs, DsExtendedTokensKeys.withAlphaXs);
+    unit(withAlphaSm, DsExtendedTokensKeys.withAlphaSm);
+    unit(withAlpha, DsExtendedTokensKeys.withAlpha);
+    unit(withAlphaLg, DsExtendedTokensKeys.withAlphaLg);
+    unit(withAlphaXl, DsExtendedTokensKeys.withAlphaXl);
+    unit(withAlphaXXl, DsExtendedTokensKeys.withAlphaXXl);
+
+    ascending(
+      withAlphaXs,
+      withAlphaSm,
+      DsExtendedTokensKeys.withAlphaXs,
+      DsExtendedTokensKeys.withAlphaSm,
+    );
+    ascending(
+      withAlphaSm,
+      withAlpha,
+      DsExtendedTokensKeys.withAlphaSm,
+      DsExtendedTokensKeys.withAlpha,
+    );
+    ascending(
+      withAlpha,
+      withAlphaLg,
+      DsExtendedTokensKeys.withAlpha,
+      DsExtendedTokensKeys.withAlphaLg,
+    );
+    ascending(
+      withAlphaLg,
+      withAlphaXl,
+      DsExtendedTokensKeys.withAlphaLg,
+      DsExtendedTokensKeys.withAlphaXl,
+    );
+    ascending(
+      withAlphaXl,
+      withAlphaXXl,
+      DsExtendedTokensKeys.withAlphaXl,
+      DsExtendedTokensKeys.withAlphaXXl,
+    );
+    if (animationDurationShort.inMilliseconds < 0) {
+      throw RangeError('animationDurationShort must be >= 0');
+    }
+    if (animationDuration.inMilliseconds < 0) {
+      throw RangeError('animationDuration must be >= 0');
+    }
+    if (animationDurationLong.inMilliseconds < 0) {
+      throw RangeError('animationDurationLong must be >= 0');
+    }
+    if (animationDurationShort > animationDuration) {
+      throw RangeError('animationDurationShort must be <= animationDuration');
+    }
+    if (animationDuration > animationDurationLong) {
+      throw RangeError('animationDuration must be <= animationDurationLong');
+    }
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (other.runtimeType != runtimeType) {
+      return false;
+    }
+    if (other is! DsExtendedTokens) {
+      return false;
+    }
+
+    return spacingXs == other.spacingXs &&
+        spacingSm == other.spacingSm &&
+        spacing == other.spacing &&
+        spacingLg == other.spacingLg &&
+        spacingXl == other.spacingXl &&
+        spacingXXl == other.spacingXXl &&
+        borderRadiusXs == other.borderRadiusXs &&
+        borderRadiusSm == other.borderRadiusSm &&
+        borderRadius == other.borderRadius &&
+        borderRadiusLg == other.borderRadiusLg &&
+        borderRadiusXl == other.borderRadiusXl &&
+        borderRadiusXXl == other.borderRadiusXXl &&
+        elevationXs == other.elevationXs &&
+        elevationSm == other.elevationSm &&
+        elevation == other.elevation &&
+        elevationLg == other.elevationLg &&
+        elevationXl == other.elevationXl &&
+        elevationXXl == other.elevationXXl &&
+        withAlphaXs == other.withAlphaXs &&
+        withAlphaSm == other.withAlphaSm &&
+        withAlpha == other.withAlpha &&
+        withAlphaLg == other.withAlphaLg &&
+        withAlphaXl == other.withAlphaXl &&
+        withAlphaXXl == other.withAlphaXXl &&
+        animationDurationShort == other.animationDurationShort &&
+        animationDuration == other.animationDuration &&
+        animationDurationLong == other.animationDurationLong;
+  }
+
+  @override
+  int get hashCode =>
+      spacingXs.hashCode ^
+      (spacingSm.hashCode * 3) ^
+      (spacing.hashCode * 5) ^
+      (spacingLg.hashCode * 7) ^
+      (spacingXl.hashCode * 11) ^
+      (spacingXXl.hashCode * 13) ^
+      (borderRadiusXs.hashCode * 17) ^
+      (borderRadiusSm.hashCode * 19) ^
+      (borderRadius.hashCode * 23) ^
+      (borderRadiusLg.hashCode * 29) ^
+      (borderRadiusXl.hashCode * 31) ^
+      (borderRadiusXXl.hashCode * 37) ^
+      (elevationXs.hashCode * 41) ^
+      (elevationSm.hashCode * 43) ^
+      (elevation.hashCode * 47) ^
+      (elevationLg.hashCode * 53) ^
+      (elevationXl.hashCode * 59) ^
+      (elevationXXl.hashCode * 61) ^
+      (withAlphaXs.hashCode * 67) ^
+      (withAlphaSm.hashCode * 71) ^
+      (withAlpha.hashCode * 73) ^
+      (withAlphaLg.hashCode * 79) ^
+      (withAlphaXl.hashCode * 83) ^
+      (withAlphaXXl.hashCode * 89) ^
+      (animationDurationShort.inMilliseconds.hashCode * 97) ^
+      (animationDuration.inMilliseconds.hashCode * 101) ^
+      (animationDurationLong.inMilliseconds.hashCode * 103);
+}

--- a/lib/src/domain/models/model_ds_sidebar_menu_item.dart
+++ b/lib/src/domain/models/model_ds_sidebar_menu_item.dart
@@ -1,0 +1,189 @@
+import 'package:flutter/foundation.dart';
+
+/// Enumerates serialized keys for [ModelDsSidebarMenuItem].
+enum DsSidebarMenuItemEnum {
+  id,
+  label,
+  iconToken,
+  enabled,
+  semanticLabel,
+}
+
+/// Approved icon tokens for the sidebar menu in Pragma DS.
+enum DsSidebarIconToken {
+  dashboard,
+  projects,
+  reports,
+  settings,
+  back,
+  home,
+  analytics,
+  lock,
+}
+
+/// Immutable model for sidebar menu entries with JSON roundtrip support.
+@immutable
+class ModelDsSidebarMenuItem {
+  factory ModelDsSidebarMenuItem({
+    required String id,
+    required String label,
+    required DsSidebarIconToken iconToken,
+    bool enabled = true,
+    String? semanticLabel,
+  }) {
+    return ModelDsSidebarMenuItem._(
+      id: id.trim(),
+      label: label.trim(),
+      iconToken: iconToken,
+      enabled: enabled,
+      semanticLabel: _nullableString(semanticLabel),
+    );
+  }
+
+  /// Builds an item from raw JSON.
+  factory ModelDsSidebarMenuItem.fromJson(Map<String, dynamic>? json) {
+    if (json == null) {
+      return empty;
+    }
+
+    return ModelDsSidebarMenuItem(
+      id: _string(json[DsSidebarMenuItemEnum.id.name]),
+      label: _string(json[DsSidebarMenuItemEnum.label.name]),
+      iconToken: _iconToken(json[DsSidebarMenuItemEnum.iconToken.name]),
+      enabled: _bool(json[DsSidebarMenuItemEnum.enabled.name], fallback: true),
+      semanticLabel:
+          _nullableString(json[DsSidebarMenuItemEnum.semanticLabel.name]),
+    );
+  }
+
+  const ModelDsSidebarMenuItem._({
+    required this.id,
+    required this.label,
+    required this.iconToken,
+    required this.enabled,
+    required this.semanticLabel,
+  });
+
+  /// Empty item useful for defaults in deserialization fallback scenarios.
+  static const ModelDsSidebarMenuItem empty = ModelDsSidebarMenuItem._(
+    id: '',
+    label: '',
+    iconToken: DsSidebarIconToken.home,
+    enabled: true,
+    semanticLabel: null,
+  );
+
+  /// Stable id for selection/state handling.
+  final String id;
+
+  /// Visible text used in expanded mode and tooltip fallback.
+  final String label;
+
+  /// Approved token of the icon rendered by the DS.
+  final DsSidebarIconToken iconToken;
+
+  /// Whether the row can be interacted with.
+  final bool enabled;
+
+  /// Optional override for accessibility label.
+  final String? semanticLabel;
+
+  /// Serializes the model to JSON.
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      DsSidebarMenuItemEnum.id.name: id,
+      DsSidebarMenuItemEnum.label.name: label,
+      DsSidebarMenuItemEnum.iconToken.name: iconToken.name,
+      DsSidebarMenuItemEnum.enabled.name: enabled,
+      DsSidebarMenuItemEnum.semanticLabel.name: semanticLabel,
+    };
+  }
+
+  /// Returns a clone overriding the provided fields.
+  ModelDsSidebarMenuItem copyWith({
+    String? id,
+    String? label,
+    DsSidebarIconToken? iconToken,
+    bool? enabled,
+    String? semanticLabel,
+  }) {
+    return ModelDsSidebarMenuItem(
+      id: id ?? this.id,
+      label: label ?? this.label,
+      iconToken: iconToken ?? this.iconToken,
+      enabled: enabled ?? this.enabled,
+      semanticLabel: semanticLabel ?? this.semanticLabel,
+    );
+  }
+
+  @override
+  String toString() => '${toJson()}';
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is ModelDsSidebarMenuItem &&
+            runtimeType == other.runtimeType &&
+            id == other.id &&
+            label == other.label &&
+            iconToken == other.iconToken &&
+            enabled == other.enabled &&
+            semanticLabel == other.semanticLabel;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        id,
+        label,
+        iconToken,
+        enabled,
+        semanticLabel,
+      );
+
+  static String _string(dynamic value) {
+    if (value is String) {
+      return value;
+    }
+    if (value == null) {
+      return '';
+    }
+    return value.toString();
+  }
+
+  static String? _nullableString(dynamic value) {
+    final String resolved = _string(value).trim();
+    if (resolved.isEmpty) {
+      return null;
+    }
+    return resolved;
+  }
+
+  static bool _bool(dynamic value, {required bool fallback}) {
+    if (value is bool) {
+      return value;
+    }
+    if (value is num) {
+      return value != 0;
+    }
+    if (value is String) {
+      final String normalized = value.toLowerCase().trim();
+      if (normalized == 'true' || normalized == '1') {
+        return true;
+      }
+      if (normalized == 'false' || normalized == '0') {
+        return false;
+      }
+    }
+    return fallback;
+  }
+
+  static DsSidebarIconToken _iconToken(dynamic value) {
+    final String serialized = _string(value).trim();
+    for (final DsSidebarIconToken token in DsSidebarIconToken.values) {
+      if (token.name == serialized) {
+        return token;
+      }
+    }
+    return DsSidebarIconToken.home;
+  }
+}

--- a/lib/src/domain/models/model_semantic_colors.dart
+++ b/lib/src/domain/models/model_semantic_colors.dart
@@ -1,0 +1,284 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+import '../../tokens/pragma_color_tokens.dart';
+
+abstract final class ModelSemanticColorsKeys {
+  static const String success = 'success';
+  static const String onSuccess = 'onSuccess';
+  static const String successContainer = 'successContainer';
+  static const String onSuccessContainer = 'onSuccessContainer';
+  static const String warning = 'warning';
+  static const String onWarning = 'onWarning';
+  static const String warningContainer = 'warningContainer';
+  static const String onWarningContainer = 'onWarningContainer';
+  static const String info = 'info';
+  static const String onInfo = 'onInfo';
+  static const String infoContainer = 'infoContainer';
+  static const String onInfoContainer = 'onInfoContainer';
+
+  static const List<String> all = <String>[
+    success,
+    onSuccess,
+    successContainer,
+    onSuccessContainer,
+    warning,
+    onWarning,
+    warningContainer,
+    onWarningContainer,
+    info,
+    onInfo,
+    infoContainer,
+    onInfoContainer,
+  ];
+}
+
+@immutable
+class ModelSemanticColors {
+  const ModelSemanticColors({
+    required this.success,
+    required this.onSuccess,
+    required this.successContainer,
+    required this.onSuccessContainer,
+    required this.warning,
+    required this.onWarning,
+    required this.warningContainer,
+    required this.onWarningContainer,
+    required this.info,
+    required this.onInfo,
+    required this.infoContainer,
+    required this.onInfoContainer,
+  });
+
+  factory ModelSemanticColors.fallbackLight() {
+    return const ModelSemanticColors(
+      success: PragmaColorTokens.success900,
+      onSuccess: PragmaColorTokens.basicWhite50,
+      successContainer: PragmaColorTokens.success50,
+      onSuccessContainer: PragmaColorTokens.success900,
+      warning: PragmaColorTokens.warning700,
+      onWarning: PragmaColorTokens.basicBlack300,
+      warningContainer: PragmaColorTokens.warning50,
+      onWarningContainer: PragmaColorTokens.warning900,
+      info: PragmaColorTokens.primaryIndigo700,
+      onInfo: PragmaColorTokens.basicWhite50,
+      infoContainer: PragmaColorTokens.primaryIndigo50,
+      onInfoContainer: PragmaColorTokens.primaryIndigo900,
+    ).._validate();
+  }
+
+  factory ModelSemanticColors.fallbackDark() {
+    return const ModelSemanticColors(
+      success: PragmaColorTokens.success300,
+      onSuccess: PragmaColorTokens.success900,
+      successContainer: PragmaColorTokens.success900,
+      onSuccessContainer: PragmaColorTokens.success50,
+      warning: PragmaColorTokens.warning300,
+      onWarning: PragmaColorTokens.warning900,
+      warningContainer: PragmaColorTokens.warning900,
+      onWarningContainer: PragmaColorTokens.warning50,
+      info: PragmaColorTokens.primaryIndigo500,
+      onInfo: PragmaColorTokens.basicBlack300,
+      infoContainer: PragmaColorTokens.primaryIndigo900,
+      onInfoContainer: PragmaColorTokens.primaryIndigo50,
+    ).._validate();
+  }
+
+  factory ModelSemanticColors.fromColorScheme(ColorScheme colorScheme) {
+    final bool isDark = colorScheme.brightness == Brightness.dark;
+    final ModelSemanticColors base = isDark
+        ? ModelSemanticColors.fallbackDark()
+        : ModelSemanticColors.fallbackLight();
+
+    Color blend(Color color) {
+      final double alpha = isDark ? 0.24 : 0.16;
+      return Color.alphaBlend(
+        color.withValues(alpha: alpha),
+        colorScheme.surface,
+      );
+    }
+
+    return base.copyWith(
+      successContainer: blend(base.success),
+      warningContainer: blend(base.warning),
+      infoContainer: blend(base.info),
+      onSuccessContainer: _onColorFor(blend(base.success)),
+      onWarningContainer: _onColorFor(blend(base.warning)),
+      onInfoContainer: _onColorFor(blend(base.info)),
+    );
+  }
+
+  factory ModelSemanticColors.fromJson(Map<String, dynamic> json) {
+    for (final String key in ModelSemanticColorsKeys.all) {
+      if (!json.containsKey(key)) {
+        throw FormatException('Missing key: $key');
+      }
+    }
+
+    Color readColor(String key) => Color(_toInteger(json[key]));
+
+    final ModelSemanticColors out = ModelSemanticColors(
+      success: readColor(ModelSemanticColorsKeys.success),
+      onSuccess: readColor(ModelSemanticColorsKeys.onSuccess),
+      successContainer: readColor(ModelSemanticColorsKeys.successContainer),
+      onSuccessContainer: readColor(ModelSemanticColorsKeys.onSuccessContainer),
+      warning: readColor(ModelSemanticColorsKeys.warning),
+      onWarning: readColor(ModelSemanticColorsKeys.onWarning),
+      warningContainer: readColor(ModelSemanticColorsKeys.warningContainer),
+      onWarningContainer: readColor(ModelSemanticColorsKeys.onWarningContainer),
+      info: readColor(ModelSemanticColorsKeys.info),
+      onInfo: readColor(ModelSemanticColorsKeys.onInfo),
+      infoContainer: readColor(ModelSemanticColorsKeys.infoContainer),
+      onInfoContainer: readColor(ModelSemanticColorsKeys.onInfoContainer),
+    );
+
+    out._validate();
+    return out;
+  }
+
+  final Color success;
+  final Color onSuccess;
+  final Color successContainer;
+  final Color onSuccessContainer;
+  final Color warning;
+  final Color onWarning;
+  final Color warningContainer;
+  final Color onWarningContainer;
+  final Color info;
+  final Color onInfo;
+  final Color infoContainer;
+  final Color onInfoContainer;
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        ModelSemanticColorsKeys.success: success.toARGB32(),
+        ModelSemanticColorsKeys.onSuccess: onSuccess.toARGB32(),
+        ModelSemanticColorsKeys.successContainer: successContainer.toARGB32(),
+        ModelSemanticColorsKeys.onSuccessContainer:
+            onSuccessContainer.toARGB32(),
+        ModelSemanticColorsKeys.warning: warning.toARGB32(),
+        ModelSemanticColorsKeys.onWarning: onWarning.toARGB32(),
+        ModelSemanticColorsKeys.warningContainer: warningContainer.toARGB32(),
+        ModelSemanticColorsKeys.onWarningContainer:
+            onWarningContainer.toARGB32(),
+        ModelSemanticColorsKeys.info: info.toARGB32(),
+        ModelSemanticColorsKeys.onInfo: onInfo.toARGB32(),
+        ModelSemanticColorsKeys.infoContainer: infoContainer.toARGB32(),
+        ModelSemanticColorsKeys.onInfoContainer: onInfoContainer.toARGB32(),
+      };
+
+  ModelSemanticColors copyWith({
+    Color? success,
+    Color? onSuccess,
+    Color? successContainer,
+    Color? onSuccessContainer,
+    Color? warning,
+    Color? onWarning,
+    Color? warningContainer,
+    Color? onWarningContainer,
+    Color? info,
+    Color? onInfo,
+    Color? infoContainer,
+    Color? onInfoContainer,
+  }) {
+    return ModelSemanticColors(
+      success: success ?? this.success,
+      onSuccess: onSuccess ?? this.onSuccess,
+      successContainer: successContainer ?? this.successContainer,
+      onSuccessContainer: onSuccessContainer ?? this.onSuccessContainer,
+      warning: warning ?? this.warning,
+      onWarning: onWarning ?? this.onWarning,
+      warningContainer: warningContainer ?? this.warningContainer,
+      onWarningContainer: onWarningContainer ?? this.onWarningContainer,
+      info: info ?? this.info,
+      onInfo: onInfo ?? this.onInfo,
+      infoContainer: infoContainer ?? this.infoContainer,
+      onInfoContainer: onInfoContainer ?? this.onInfoContainer,
+    ).._validate();
+  }
+
+  void _validate() {
+    _minContrast(success, onSuccess, 'success/onSuccess');
+    _minContrast(
+      successContainer,
+      onSuccessContainer,
+      'successContainer/onSuccessContainer',
+    );
+    _minContrast(warning, onWarning, 'warning/onWarning');
+    _minContrast(
+      warningContainer,
+      onWarningContainer,
+      'warningContainer/onWarningContainer',
+    );
+    _minContrast(info, onInfo, 'info/onInfo');
+    _minContrast(
+      infoContainer,
+      onInfoContainer,
+      'infoContainer/onInfoContainer',
+    );
+  }
+
+  static void _minContrast(Color bg, Color fg, String name) {
+    final double ratio = _contrastRatio(bg, fg);
+    if (ratio < 3.0) {
+      throw RangeError('$name contrast too low. Got $ratio (< 3.0)');
+    }
+  }
+
+  static double _contrastRatio(Color a, Color b) {
+    final double l1 = a.computeLuminance();
+    final double l2 = b.computeLuminance();
+    final double hi = l1 > l2 ? l1 : l2;
+    final double lo = l1 > l2 ? l2 : l1;
+    return (hi + 0.05) / (lo + 0.05);
+  }
+
+  static Color _onColorFor(Color background) {
+    const Color white = Colors.white;
+    const Color black = Colors.black;
+    final double whiteContrast = _contrastRatio(background, white);
+    final double blackContrast = _contrastRatio(background, black);
+    return whiteContrast >= blackContrast ? white : black;
+  }
+
+  static int _toInteger(dynamic value) {
+    if (value is int) {
+      return value;
+    }
+    if (value is num) {
+      return value.round();
+    }
+    if (value is String) {
+      return int.tryParse(value.trim()) ??
+          double.tryParse(value.trim())?.round() ??
+          0;
+    }
+    return 0;
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (other is! ModelSemanticColors) {
+      return false;
+    }
+    return mapEquals(toJson(), other.toJson());
+  }
+
+  @override
+  int get hashCode => Object.hashAll(<Object?>[
+        success,
+        onSuccess,
+        successContainer,
+        onSuccessContainer,
+        warning,
+        onWarning,
+        warningContainer,
+        onWarningContainer,
+        info,
+        onInfo,
+        infoContainer,
+        onInfoContainer,
+      ]);
+}

--- a/lib/src/domain/models/model_theme_data.dart
+++ b/lib/src/domain/models/model_theme_data.dart
@@ -1,0 +1,505 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+import '../../tokens/pragma_colors.dart';
+import '../../tokens/pragma_typography.dart';
+
+abstract final class ModelThemeDataKeys {
+  static const String useMaterial3 = 'useMaterial3';
+  static const String lightScheme = 'lightScheme';
+  static const String darkScheme = 'darkScheme';
+  static const String lightTextTheme = 'lightTextTheme';
+  static const String darkTextTheme = 'darkTextTheme';
+}
+
+abstract final class _ColorSchemeKeys {
+  static const String brightness = 'brightness';
+  static const String primary = 'primary';
+  static const String onPrimary = 'onPrimary';
+  static const String primaryContainer = 'primaryContainer';
+  static const String onPrimaryContainer = 'onPrimaryContainer';
+  static const String secondary = 'secondary';
+  static const String onSecondary = 'onSecondary';
+  static const String secondaryContainer = 'secondaryContainer';
+  static const String onSecondaryContainer = 'onSecondaryContainer';
+  static const String tertiary = 'tertiary';
+  static const String onTertiary = 'onTertiary';
+  static const String tertiaryContainer = 'tertiaryContainer';
+  static const String onTertiaryContainer = 'onTertiaryContainer';
+  static const String error = 'error';
+  static const String onError = 'onError';
+  static const String errorContainer = 'errorContainer';
+  static const String onErrorContainer = 'onErrorContainer';
+  static const String surface = 'surface';
+  static const String onSurface = 'onSurface';
+  static const String onSurfaceVariant = 'onSurfaceVariant';
+  static const String outline = 'outline';
+  static const String outlineVariant = 'outlineVariant';
+  static const String shadow = 'shadow';
+  static const String scrim = 'scrim';
+  static const String inverseSurface = 'inverseSurface';
+  static const String inversePrimary = 'inversePrimary';
+  static const String surfaceTint = 'surfaceTint';
+  static const String surfaceContainerHighest = 'surfaceContainerHighest';
+}
+
+abstract final class _TextThemeKeys {
+  static const String displayLarge = 'displayLarge';
+  static const String displayMedium = 'displayMedium';
+  static const String displaySmall = 'displaySmall';
+  static const String headlineLarge = 'headlineLarge';
+  static const String headlineMedium = 'headlineMedium';
+  static const String headlineSmall = 'headlineSmall';
+  static const String titleLarge = 'titleLarge';
+  static const String titleMedium = 'titleMedium';
+  static const String titleSmall = 'titleSmall';
+  static const String bodyLarge = 'bodyLarge';
+  static const String bodyMedium = 'bodyMedium';
+  static const String bodySmall = 'bodySmall';
+  static const String labelLarge = 'labelLarge';
+  static const String labelMedium = 'labelMedium';
+  static const String labelSmall = 'labelSmall';
+}
+
+abstract final class _TextStyleKeys {
+  static const String color = 'color';
+  static const String fontSize = 'fontSize';
+  static const String fontWeight = 'fontWeight';
+  static const String height = 'height';
+  static const String letterSpacing = 'letterSpacing';
+  static const String fontFamily = 'fontFamily';
+}
+
+@immutable
+class ModelThemeData {
+  const ModelThemeData({
+    required this.lightScheme,
+    required this.darkScheme,
+    required this.lightTextTheme,
+    required this.darkTextTheme,
+    required this.useMaterial3,
+  });
+
+  factory ModelThemeData.pragmaDefault() {
+    return ModelThemeData(
+      lightScheme: PragmaColors.lightScheme,
+      darkScheme: PragmaColors.darkScheme,
+      lightTextTheme: PragmaTypography.textTheme(),
+      darkTextTheme: PragmaTypography.textTheme(brightness: Brightness.dark),
+      useMaterial3: true,
+    );
+  }
+
+  factory ModelThemeData.fromJson(Map<String, dynamic> json) {
+    final Object? useMaterial3Raw = json[ModelThemeDataKeys.useMaterial3];
+    final Object? lightSchemeRaw = json[ModelThemeDataKeys.lightScheme];
+    final Object? darkSchemeRaw = json[ModelThemeDataKeys.darkScheme];
+    final Object? lightTextThemeRaw = json[ModelThemeDataKeys.lightTextTheme];
+    final Object? darkTextThemeRaw = json[ModelThemeDataKeys.darkTextTheme];
+
+    if (useMaterial3Raw is! bool) {
+      throw const FormatException('Expected bool for useMaterial3');
+    }
+    if (lightSchemeRaw is! Map<String, dynamic>) {
+      throw const FormatException('Expected map for lightScheme');
+    }
+    if (darkSchemeRaw is! Map<String, dynamic>) {
+      throw const FormatException('Expected map for darkScheme');
+    }
+
+    return ModelThemeData(
+      useMaterial3: useMaterial3Raw,
+      lightScheme: _schemeFromJson(lightSchemeRaw),
+      darkScheme: _schemeFromJson(darkSchemeRaw),
+      lightTextTheme: lightTextThemeRaw is Map<String, dynamic>
+          ? _textThemeFromJson(lightTextThemeRaw)
+          : PragmaTypography.textTheme(),
+      darkTextTheme: darkTextThemeRaw is Map<String, dynamic>
+          ? _textThemeFromJson(darkTextThemeRaw)
+          : PragmaTypography.textTheme(brightness: Brightness.dark),
+    );
+  }
+
+  final ColorScheme lightScheme;
+  final ColorScheme darkScheme;
+  final TextTheme lightTextTheme;
+  final TextTheme darkTextTheme;
+  final bool useMaterial3;
+
+  ThemeData toThemeData({required Brightness brightness}) {
+    final bool isDark = brightness == Brightness.dark;
+    return ThemeData(
+      useMaterial3: useMaterial3,
+      brightness: brightness,
+      colorScheme: isDark ? darkScheme : lightScheme,
+      textTheme: isDark ? darkTextTheme : lightTextTheme,
+    );
+  }
+
+  static ModelThemeData fromThemeData({
+    required ThemeData lightTheme,
+    required ThemeData darkTheme,
+  }) {
+    return ModelThemeData(
+      lightScheme: lightTheme.colorScheme,
+      darkScheme: darkTheme.colorScheme,
+      lightTextTheme: lightTheme.textTheme,
+      darkTextTheme: darkTheme.textTheme,
+      useMaterial3: lightTheme.useMaterial3,
+    );
+  }
+
+  ModelThemeData copyWith({
+    ColorScheme? lightScheme,
+    ColorScheme? darkScheme,
+    TextTheme? lightTextTheme,
+    TextTheme? darkTextTheme,
+    bool? useMaterial3,
+  }) {
+    return ModelThemeData(
+      lightScheme: lightScheme ?? this.lightScheme,
+      darkScheme: darkScheme ?? this.darkScheme,
+      lightTextTheme: lightTextTheme ?? this.lightTextTheme,
+      darkTextTheme: darkTextTheme ?? this.darkTextTheme,
+      useMaterial3: useMaterial3 ?? this.useMaterial3,
+    );
+  }
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        ModelThemeDataKeys.useMaterial3: useMaterial3,
+        ModelThemeDataKeys.lightScheme: _schemeToJson(lightScheme),
+        ModelThemeDataKeys.darkScheme: _schemeToJson(darkScheme),
+        ModelThemeDataKeys.lightTextTheme: _textThemeToJson(lightTextTheme),
+        ModelThemeDataKeys.darkTextTheme: _textThemeToJson(darkTextTheme),
+      };
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (other is! ModelThemeData) {
+      return false;
+    }
+    return mapEquals(toJson(), other.toJson());
+  }
+
+  @override
+  int get hashCode => Object.hashAll(<Object?>[
+        useMaterial3,
+        lightScheme,
+        darkScheme,
+        lightTextTheme,
+        darkTextTheme,
+      ]);
+
+  static Map<String, dynamic> _schemeToJson(ColorScheme s) {
+    return <String, dynamic>{
+      _ColorSchemeKeys.brightness: s.brightness.name,
+      _ColorSchemeKeys.primary: s.primary.toARGB32(),
+      _ColorSchemeKeys.onPrimary: s.onPrimary.toARGB32(),
+      _ColorSchemeKeys.primaryContainer: s.primaryContainer.toARGB32(),
+      _ColorSchemeKeys.onPrimaryContainer: s.onPrimaryContainer.toARGB32(),
+      _ColorSchemeKeys.secondary: s.secondary.toARGB32(),
+      _ColorSchemeKeys.onSecondary: s.onSecondary.toARGB32(),
+      _ColorSchemeKeys.secondaryContainer: s.secondaryContainer.toARGB32(),
+      _ColorSchemeKeys.onSecondaryContainer: s.onSecondaryContainer.toARGB32(),
+      _ColorSchemeKeys.tertiary: s.tertiary.toARGB32(),
+      _ColorSchemeKeys.onTertiary: s.onTertiary.toARGB32(),
+      _ColorSchemeKeys.tertiaryContainer: s.tertiaryContainer.toARGB32(),
+      _ColorSchemeKeys.onTertiaryContainer: s.onTertiaryContainer.toARGB32(),
+      _ColorSchemeKeys.error: s.error.toARGB32(),
+      _ColorSchemeKeys.onError: s.onError.toARGB32(),
+      _ColorSchemeKeys.errorContainer: s.errorContainer.toARGB32(),
+      _ColorSchemeKeys.onErrorContainer: s.onErrorContainer.toARGB32(),
+      _ColorSchemeKeys.surface: s.surface.toARGB32(),
+      _ColorSchemeKeys.onSurface: s.onSurface.toARGB32(),
+      _ColorSchemeKeys.onSurfaceVariant: s.onSurfaceVariant.toARGB32(),
+      _ColorSchemeKeys.outline: s.outline.toARGB32(),
+      _ColorSchemeKeys.outlineVariant: s.outlineVariant.toARGB32(),
+      _ColorSchemeKeys.shadow: s.shadow.toARGB32(),
+      _ColorSchemeKeys.scrim: s.scrim.toARGB32(),
+      _ColorSchemeKeys.inverseSurface: s.inverseSurface.toARGB32(),
+      _ColorSchemeKeys.inversePrimary: s.inversePrimary.toARGB32(),
+      _ColorSchemeKeys.surfaceTint: s.surfaceTint.toARGB32(),
+      _ColorSchemeKeys.surfaceContainerHighest:
+          s.surfaceContainerHighest.toARGB32(),
+    };
+  }
+
+  static ColorScheme _schemeFromJson(Map<String, dynamic> json) {
+    final Brightness brightness = (json[_ColorSchemeKeys.brightness] == 'dark')
+        ? Brightness.dark
+        : Brightness.light;
+
+    final ColorScheme base = brightness == Brightness.dark
+        ? PragmaColors.darkScheme
+        : PragmaColors.lightScheme;
+
+    return base.copyWith(
+      primary: _readColor(json, _ColorSchemeKeys.primary, base.primary),
+      onPrimary: _readColor(json, _ColorSchemeKeys.onPrimary, base.onPrimary),
+      primaryContainer: _readColor(
+        json,
+        _ColorSchemeKeys.primaryContainer,
+        base.primaryContainer,
+      ),
+      onPrimaryContainer: _readColor(
+        json,
+        _ColorSchemeKeys.onPrimaryContainer,
+        base.onPrimaryContainer,
+      ),
+      secondary: _readColor(json, _ColorSchemeKeys.secondary, base.secondary),
+      onSecondary:
+          _readColor(json, _ColorSchemeKeys.onSecondary, base.onSecondary),
+      secondaryContainer: _readColor(
+        json,
+        _ColorSchemeKeys.secondaryContainer,
+        base.secondaryContainer,
+      ),
+      onSecondaryContainer: _readColor(
+        json,
+        _ColorSchemeKeys.onSecondaryContainer,
+        base.onSecondaryContainer,
+      ),
+      tertiary: _readColor(json, _ColorSchemeKeys.tertiary, base.tertiary),
+      onTertiary:
+          _readColor(json, _ColorSchemeKeys.onTertiary, base.onTertiary),
+      tertiaryContainer: _readColor(
+        json,
+        _ColorSchemeKeys.tertiaryContainer,
+        base.tertiaryContainer,
+      ),
+      onTertiaryContainer: _readColor(
+        json,
+        _ColorSchemeKeys.onTertiaryContainer,
+        base.onTertiaryContainer,
+      ),
+      error: _readColor(json, _ColorSchemeKeys.error, base.error),
+      onError: _readColor(json, _ColorSchemeKeys.onError, base.onError),
+      errorContainer: _readColor(
+        json,
+        _ColorSchemeKeys.errorContainer,
+        base.errorContainer,
+      ),
+      onErrorContainer: _readColor(
+        json,
+        _ColorSchemeKeys.onErrorContainer,
+        base.onErrorContainer,
+      ),
+      surface: _readColor(json, _ColorSchemeKeys.surface, base.surface),
+      onSurface: _readColor(json, _ColorSchemeKeys.onSurface, base.onSurface),
+      onSurfaceVariant: _readColor(
+        json,
+        _ColorSchemeKeys.onSurfaceVariant,
+        base.onSurfaceVariant,
+      ),
+      outline: _readColor(json, _ColorSchemeKeys.outline, base.outline),
+      outlineVariant: _readColor(
+        json,
+        _ColorSchemeKeys.outlineVariant,
+        base.outlineVariant,
+      ),
+      shadow: _readColor(json, _ColorSchemeKeys.shadow, base.shadow),
+      scrim: _readColor(json, _ColorSchemeKeys.scrim, base.scrim),
+      inverseSurface: _readColor(
+        json,
+        _ColorSchemeKeys.inverseSurface,
+        base.inverseSurface,
+      ),
+      inversePrimary: _readColor(
+        json,
+        _ColorSchemeKeys.inversePrimary,
+        base.inversePrimary,
+      ),
+      surfaceTint:
+          _readColor(json, _ColorSchemeKeys.surfaceTint, base.surfaceTint),
+      surfaceContainerHighest: _readColor(
+        json,
+        _ColorSchemeKeys.surfaceContainerHighest,
+        base.surfaceContainerHighest,
+      ),
+    );
+  }
+
+  static Map<String, dynamic> _textThemeToJson(TextTheme theme) {
+    return <String, dynamic>{
+      _TextThemeKeys.displayLarge: _textStyleToJson(theme.displayLarge),
+      _TextThemeKeys.displayMedium: _textStyleToJson(theme.displayMedium),
+      _TextThemeKeys.displaySmall: _textStyleToJson(theme.displaySmall),
+      _TextThemeKeys.headlineLarge: _textStyleToJson(theme.headlineLarge),
+      _TextThemeKeys.headlineMedium: _textStyleToJson(theme.headlineMedium),
+      _TextThemeKeys.headlineSmall: _textStyleToJson(theme.headlineSmall),
+      _TextThemeKeys.titleLarge: _textStyleToJson(theme.titleLarge),
+      _TextThemeKeys.titleMedium: _textStyleToJson(theme.titleMedium),
+      _TextThemeKeys.titleSmall: _textStyleToJson(theme.titleSmall),
+      _TextThemeKeys.bodyLarge: _textStyleToJson(theme.bodyLarge),
+      _TextThemeKeys.bodyMedium: _textStyleToJson(theme.bodyMedium),
+      _TextThemeKeys.bodySmall: _textStyleToJson(theme.bodySmall),
+      _TextThemeKeys.labelLarge: _textStyleToJson(theme.labelLarge),
+      _TextThemeKeys.labelMedium: _textStyleToJson(theme.labelMedium),
+      _TextThemeKeys.labelSmall: _textStyleToJson(theme.labelSmall),
+    };
+  }
+
+  static TextTheme _textThemeFromJson(Map<String, dynamic> json) {
+    final TextTheme base = PragmaTypography.textTheme();
+    return TextTheme(
+      displayLarge: _textStyleFromJson(
+        json[_TextThemeKeys.displayLarge],
+        fallback: base.displayLarge,
+      ),
+      displayMedium: _textStyleFromJson(
+        json[_TextThemeKeys.displayMedium],
+        fallback: base.displayMedium,
+      ),
+      displaySmall: _textStyleFromJson(
+        json[_TextThemeKeys.displaySmall],
+        fallback: base.displaySmall,
+      ),
+      headlineLarge: _textStyleFromJson(
+        json[_TextThemeKeys.headlineLarge],
+        fallback: base.headlineLarge,
+      ),
+      headlineMedium: _textStyleFromJson(
+        json[_TextThemeKeys.headlineMedium],
+        fallback: base.headlineMedium,
+      ),
+      headlineSmall: _textStyleFromJson(
+        json[_TextThemeKeys.headlineSmall],
+        fallback: base.headlineSmall,
+      ),
+      titleLarge: _textStyleFromJson(
+        json[_TextThemeKeys.titleLarge],
+        fallback: base.titleLarge,
+      ),
+      titleMedium: _textStyleFromJson(
+        json[_TextThemeKeys.titleMedium],
+        fallback: base.titleMedium,
+      ),
+      titleSmall: _textStyleFromJson(
+        json[_TextThemeKeys.titleSmall],
+        fallback: base.titleSmall,
+      ),
+      bodyLarge: _textStyleFromJson(
+        json[_TextThemeKeys.bodyLarge],
+        fallback: base.bodyLarge,
+      ),
+      bodyMedium: _textStyleFromJson(
+        json[_TextThemeKeys.bodyMedium],
+        fallback: base.bodyMedium,
+      ),
+      bodySmall: _textStyleFromJson(
+        json[_TextThemeKeys.bodySmall],
+        fallback: base.bodySmall,
+      ),
+      labelLarge: _textStyleFromJson(
+        json[_TextThemeKeys.labelLarge],
+        fallback: base.labelLarge,
+      ),
+      labelMedium: _textStyleFromJson(
+        json[_TextThemeKeys.labelMedium],
+        fallback: base.labelMedium,
+      ),
+      labelSmall: _textStyleFromJson(
+        json[_TextThemeKeys.labelSmall],
+        fallback: base.labelSmall,
+      ),
+    );
+  }
+
+  static Map<String, dynamic>? _textStyleToJson(TextStyle? style) {
+    if (style == null) {
+      return null;
+    }
+    return <String, dynamic>{
+      _TextStyleKeys.color: style.color?.toARGB32(),
+      _TextStyleKeys.fontSize: style.fontSize,
+      _TextStyleKeys.fontWeight: style.fontWeight?.value,
+      _TextStyleKeys.height: style.height,
+      _TextStyleKeys.letterSpacing: style.letterSpacing,
+      _TextStyleKeys.fontFamily: style.fontFamily,
+    };
+  }
+
+  static TextStyle? _textStyleFromJson(
+    Object? raw, {
+    required TextStyle? fallback,
+  }) {
+    if (raw is! Map<String, dynamic>) {
+      return fallback;
+    }
+
+    final Color? color = _readNullableColor(raw[_TextStyleKeys.color]);
+    final double? fontSize = _readNullableDouble(raw[_TextStyleKeys.fontSize]);
+    final int? fontWeightValue =
+        _readNullableInt(raw[_TextStyleKeys.fontWeight]);
+    final FontWeight? fontWeight = fontWeightValue == null
+        ? null
+        : FontWeight.values[fontWeightValue ~/ 100 - 1];
+    final double? height = _readNullableDouble(raw[_TextStyleKeys.height]);
+    final double? letterSpacing =
+        _readNullableDouble(raw[_TextStyleKeys.letterSpacing]);
+    final String? fontFamily = raw[_TextStyleKeys.fontFamily] as String?;
+
+    final TextStyle base = fallback ?? const TextStyle();
+    return base.copyWith(
+      color: color,
+      fontSize: fontSize,
+      fontWeight: fontWeight,
+      height: height,
+      letterSpacing: letterSpacing,
+      fontFamily: fontFamily,
+    );
+  }
+
+  static Color _readColor(
+    Map<String, dynamic> json,
+    String key,
+    Color fallback,
+  ) {
+    final Object? value = json[key];
+    final Color? parsed = _readNullableColor(value);
+    return parsed ?? fallback;
+  }
+
+  static Color? _readNullableColor(Object? raw) {
+    final int? value = _readNullableInt(raw);
+    if (value == null) {
+      return null;
+    }
+    return Color(value);
+  }
+
+  static int? _readNullableInt(Object? raw) {
+    if (raw == null) {
+      return null;
+    }
+    if (raw is int) {
+      return raw;
+    }
+    if (raw is num) {
+      return raw.round();
+    }
+    if (raw is String) {
+      return int.tryParse(raw.trim()) ?? double.tryParse(raw.trim())?.round();
+    }
+    return null;
+  }
+
+  static double? _readNullableDouble(Object? raw) {
+    if (raw == null) {
+      return null;
+    }
+    if (raw is double) {
+      return raw;
+    }
+    if (raw is num) {
+      return raw.toDouble();
+    }
+    if (raw is String) {
+      return double.tryParse(raw.trim());
+    }
+    return null;
+  }
+}

--- a/lib/src/domain/models/model_typography_tokens.dart
+++ b/lib/src/domain/models/model_typography_tokens.dart
@@ -1,0 +1,379 @@
+import 'package:flutter/foundation.dart';
+
+abstract final class ModelTypographyTokenStyleKeys {
+  static const String fontSize = 'fontSize';
+  static const String lineHeight = 'lineHeight';
+  static const String fontWeight = 'fontWeight';
+  static const String letterSpacing = 'letterSpacing';
+}
+
+@immutable
+class ModelTypographyTokenStyle {
+  const ModelTypographyTokenStyle({
+    required this.fontSize,
+    required this.lineHeight,
+    required this.fontWeight,
+    this.letterSpacing,
+  });
+
+  factory ModelTypographyTokenStyle.fromJson(Map<String, dynamic> json) {
+    return ModelTypographyTokenStyle(
+      fontSize: _toDouble(json[ModelTypographyTokenStyleKeys.fontSize]),
+      lineHeight: _toDouble(json[ModelTypographyTokenStyleKeys.lineHeight]),
+      fontWeight: _toInt(json[ModelTypographyTokenStyleKeys.fontWeight]),
+      letterSpacing:
+          _toNullableDouble(json[ModelTypographyTokenStyleKeys.letterSpacing]),
+    ).._validate();
+  }
+
+  final double fontSize;
+  final double lineHeight;
+  final int fontWeight;
+  final double? letterSpacing;
+
+  ModelTypographyTokenStyle copyWith({
+    double? fontSize,
+    double? lineHeight,
+    int? fontWeight,
+    double? letterSpacing,
+  }) {
+    return ModelTypographyTokenStyle(
+      fontSize: fontSize ?? this.fontSize,
+      lineHeight: lineHeight ?? this.lineHeight,
+      fontWeight: fontWeight ?? this.fontWeight,
+      letterSpacing: letterSpacing ?? this.letterSpacing,
+    ).._validate();
+  }
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        ModelTypographyTokenStyleKeys.fontSize: fontSize,
+        ModelTypographyTokenStyleKeys.lineHeight: lineHeight,
+        ModelTypographyTokenStyleKeys.fontWeight: fontWeight,
+        ModelTypographyTokenStyleKeys.letterSpacing: letterSpacing,
+      };
+
+  void _validate() {
+    if (!fontSize.isFinite || fontSize <= 0) {
+      throw RangeError('fontSize must be > 0');
+    }
+    if (!lineHeight.isFinite || lineHeight <= 0) {
+      throw RangeError('lineHeight must be > 0');
+    }
+    if (fontWeight < 100 || fontWeight > 900) {
+      throw RangeError('fontWeight must be in 100..900');
+    }
+  }
+
+  static double _toDouble(dynamic value) {
+    if (value is num) {
+      return value.toDouble();
+    }
+    if (value is String) {
+      return double.tryParse(value.trim()) ?? 0;
+    }
+    return 0;
+  }
+
+  static int _toInt(dynamic value) {
+    if (value is int) {
+      return value;
+    }
+    if (value is num) {
+      return value.round();
+    }
+    if (value is String) {
+      return int.tryParse(value.trim()) ??
+          double.tryParse(value.trim())?.round() ??
+          0;
+    }
+    return 0;
+  }
+
+  static double? _toNullableDouble(dynamic value) {
+    if (value == null) {
+      return null;
+    }
+    if (value is num) {
+      return value.toDouble();
+    }
+    if (value is String) {
+      return double.tryParse(value.trim());
+    }
+    return null;
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    return other is ModelTypographyTokenStyle &&
+        other.fontSize == fontSize &&
+        other.lineHeight == lineHeight &&
+        other.fontWeight == fontWeight &&
+        other.letterSpacing == letterSpacing;
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(fontSize, lineHeight, fontWeight, letterSpacing);
+}
+
+abstract final class ModelTypographyTokensKeys {
+  static const String displayLarge = 'displayLarge';
+  static const String displayMedium = 'displayMedium';
+  static const String displaySmall = 'displaySmall';
+  static const String headlineLarge = 'headlineLarge';
+  static const String headlineMedium = 'headlineMedium';
+  static const String headlineSmall = 'headlineSmall';
+  static const String titleLarge = 'titleLarge';
+  static const String titleMedium = 'titleMedium';
+  static const String titleSmall = 'titleSmall';
+  static const String bodyLarge = 'bodyLarge';
+  static const String bodyMedium = 'bodyMedium';
+  static const String bodySmall = 'bodySmall';
+  static const String labelLarge = 'labelLarge';
+  static const String labelMedium = 'labelMedium';
+  static const String labelSmall = 'labelSmall';
+}
+
+@immutable
+class ModelTypographyTokens {
+  const ModelTypographyTokens({
+    required this.displayLarge,
+    required this.displayMedium,
+    required this.displaySmall,
+    required this.headlineLarge,
+    required this.headlineMedium,
+    required this.headlineSmall,
+    required this.titleLarge,
+    required this.titleMedium,
+    required this.titleSmall,
+    required this.bodyLarge,
+    required this.bodyMedium,
+    required this.bodySmall,
+    required this.labelLarge,
+    required this.labelMedium,
+    required this.labelSmall,
+  });
+
+  factory ModelTypographyTokens.pragmaDefault() {
+    return const ModelTypographyTokens(
+      displayLarge: ModelTypographyTokenStyle(
+        fontSize: 72,
+        lineHeight: 76,
+        fontWeight: 600,
+      ),
+      displayMedium: ModelTypographyTokenStyle(
+        fontSize: 60,
+        lineHeight: 64,
+        fontWeight: 600,
+      ),
+      displaySmall: ModelTypographyTokenStyle(
+        fontSize: 46,
+        lineHeight: 50,
+        fontWeight: 600,
+      ),
+      headlineLarge: ModelTypographyTokenStyle(
+        fontSize: 36,
+        lineHeight: 40,
+        fontWeight: 600,
+      ),
+      headlineMedium: ModelTypographyTokenStyle(
+        fontSize: 30,
+        lineHeight: 34,
+        fontWeight: 600,
+      ),
+      headlineSmall: ModelTypographyTokenStyle(
+        fontSize: 26,
+        lineHeight: 30,
+        fontWeight: 600,
+      ),
+      titleLarge: ModelTypographyTokenStyle(
+        fontSize: 21,
+        lineHeight: 25,
+        fontWeight: 600,
+      ),
+      titleMedium: ModelTypographyTokenStyle(
+        fontSize: 16,
+        lineHeight: 20,
+        fontWeight: 600,
+      ),
+      titleSmall: ModelTypographyTokenStyle(
+        fontSize: 30,
+        lineHeight: 34,
+        fontWeight: 400,
+      ),
+      bodyLarge: ModelTypographyTokenStyle(
+        fontSize: 21,
+        lineHeight: 25,
+        fontWeight: 400,
+      ),
+      bodyMedium: ModelTypographyTokenStyle(
+        fontSize: 16,
+        lineHeight: 20,
+        fontWeight: 400,
+      ),
+      bodySmall: ModelTypographyTokenStyle(
+        fontSize: 14,
+        lineHeight: 18,
+        fontWeight: 400,
+      ),
+      labelLarge: ModelTypographyTokenStyle(
+        fontSize: 12,
+        lineHeight: 16,
+        fontWeight: 700,
+      ),
+      labelMedium: ModelTypographyTokenStyle(
+        fontSize: 12,
+        lineHeight: 16,
+        fontWeight: 400,
+      ),
+      labelSmall: ModelTypographyTokenStyle(
+        fontSize: 10,
+        lineHeight: 14,
+        fontWeight: 400,
+      ),
+    );
+  }
+
+  factory ModelTypographyTokens.fromJson(Map<String, dynamic> json) {
+    ModelTypographyTokenStyle read(String key) {
+      final Object? raw = json[key];
+      if (raw is! Map<String, dynamic>) {
+        throw FormatException('Expected map for $key');
+      }
+      return ModelTypographyTokenStyle.fromJson(raw);
+    }
+
+    return ModelTypographyTokens(
+      displayLarge: read(ModelTypographyTokensKeys.displayLarge),
+      displayMedium: read(ModelTypographyTokensKeys.displayMedium),
+      displaySmall: read(ModelTypographyTokensKeys.displaySmall),
+      headlineLarge: read(ModelTypographyTokensKeys.headlineLarge),
+      headlineMedium: read(ModelTypographyTokensKeys.headlineMedium),
+      headlineSmall: read(ModelTypographyTokensKeys.headlineSmall),
+      titleLarge: read(ModelTypographyTokensKeys.titleLarge),
+      titleMedium: read(ModelTypographyTokensKeys.titleMedium),
+      titleSmall: read(ModelTypographyTokensKeys.titleSmall),
+      bodyLarge: read(ModelTypographyTokensKeys.bodyLarge),
+      bodyMedium: read(ModelTypographyTokensKeys.bodyMedium),
+      bodySmall: read(ModelTypographyTokensKeys.bodySmall),
+      labelLarge: read(ModelTypographyTokensKeys.labelLarge),
+      labelMedium: read(ModelTypographyTokensKeys.labelMedium),
+      labelSmall: read(ModelTypographyTokensKeys.labelSmall),
+    );
+  }
+
+  final ModelTypographyTokenStyle displayLarge;
+  final ModelTypographyTokenStyle displayMedium;
+  final ModelTypographyTokenStyle displaySmall;
+  final ModelTypographyTokenStyle headlineLarge;
+  final ModelTypographyTokenStyle headlineMedium;
+  final ModelTypographyTokenStyle headlineSmall;
+  final ModelTypographyTokenStyle titleLarge;
+  final ModelTypographyTokenStyle titleMedium;
+  final ModelTypographyTokenStyle titleSmall;
+  final ModelTypographyTokenStyle bodyLarge;
+  final ModelTypographyTokenStyle bodyMedium;
+  final ModelTypographyTokenStyle bodySmall;
+  final ModelTypographyTokenStyle labelLarge;
+  final ModelTypographyTokenStyle labelMedium;
+  final ModelTypographyTokenStyle labelSmall;
+
+  ModelTypographyTokens copyWith({
+    ModelTypographyTokenStyle? displayLarge,
+    ModelTypographyTokenStyle? displayMedium,
+    ModelTypographyTokenStyle? displaySmall,
+    ModelTypographyTokenStyle? headlineLarge,
+    ModelTypographyTokenStyle? headlineMedium,
+    ModelTypographyTokenStyle? headlineSmall,
+    ModelTypographyTokenStyle? titleLarge,
+    ModelTypographyTokenStyle? titleMedium,
+    ModelTypographyTokenStyle? titleSmall,
+    ModelTypographyTokenStyle? bodyLarge,
+    ModelTypographyTokenStyle? bodyMedium,
+    ModelTypographyTokenStyle? bodySmall,
+    ModelTypographyTokenStyle? labelLarge,
+    ModelTypographyTokenStyle? labelMedium,
+    ModelTypographyTokenStyle? labelSmall,
+  }) {
+    return ModelTypographyTokens(
+      displayLarge: displayLarge ?? this.displayLarge,
+      displayMedium: displayMedium ?? this.displayMedium,
+      displaySmall: displaySmall ?? this.displaySmall,
+      headlineLarge: headlineLarge ?? this.headlineLarge,
+      headlineMedium: headlineMedium ?? this.headlineMedium,
+      headlineSmall: headlineSmall ?? this.headlineSmall,
+      titleLarge: titleLarge ?? this.titleLarge,
+      titleMedium: titleMedium ?? this.titleMedium,
+      titleSmall: titleSmall ?? this.titleSmall,
+      bodyLarge: bodyLarge ?? this.bodyLarge,
+      bodyMedium: bodyMedium ?? this.bodyMedium,
+      bodySmall: bodySmall ?? this.bodySmall,
+      labelLarge: labelLarge ?? this.labelLarge,
+      labelMedium: labelMedium ?? this.labelMedium,
+      labelSmall: labelSmall ?? this.labelSmall,
+    );
+  }
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        ModelTypographyTokensKeys.displayLarge: displayLarge.toJson(),
+        ModelTypographyTokensKeys.displayMedium: displayMedium.toJson(),
+        ModelTypographyTokensKeys.displaySmall: displaySmall.toJson(),
+        ModelTypographyTokensKeys.headlineLarge: headlineLarge.toJson(),
+        ModelTypographyTokensKeys.headlineMedium: headlineMedium.toJson(),
+        ModelTypographyTokensKeys.headlineSmall: headlineSmall.toJson(),
+        ModelTypographyTokensKeys.titleLarge: titleLarge.toJson(),
+        ModelTypographyTokensKeys.titleMedium: titleMedium.toJson(),
+        ModelTypographyTokensKeys.titleSmall: titleSmall.toJson(),
+        ModelTypographyTokensKeys.bodyLarge: bodyLarge.toJson(),
+        ModelTypographyTokensKeys.bodyMedium: bodyMedium.toJson(),
+        ModelTypographyTokensKeys.bodySmall: bodySmall.toJson(),
+        ModelTypographyTokensKeys.labelLarge: labelLarge.toJson(),
+        ModelTypographyTokensKeys.labelMedium: labelMedium.toJson(),
+        ModelTypographyTokensKeys.labelSmall: labelSmall.toJson(),
+      };
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    return other is ModelTypographyTokens &&
+        other.displayLarge == displayLarge &&
+        other.displayMedium == displayMedium &&
+        other.displaySmall == displaySmall &&
+        other.headlineLarge == headlineLarge &&
+        other.headlineMedium == headlineMedium &&
+        other.headlineSmall == headlineSmall &&
+        other.titleLarge == titleLarge &&
+        other.titleMedium == titleMedium &&
+        other.titleSmall == titleSmall &&
+        other.bodyLarge == bodyLarge &&
+        other.bodyMedium == bodyMedium &&
+        other.bodySmall == bodySmall &&
+        other.labelLarge == labelLarge &&
+        other.labelMedium == labelMedium &&
+        other.labelSmall == labelSmall;
+  }
+
+  @override
+  int get hashCode => Object.hashAll(<Object?>[
+        displayLarge,
+        displayMedium,
+        displaySmall,
+        headlineLarge,
+        headlineMedium,
+        headlineSmall,
+        titleLarge,
+        titleMedium,
+        titleSmall,
+        bodyLarge,
+        bodyMedium,
+        bodySmall,
+        labelLarge,
+        labelMedium,
+        labelSmall,
+      ]);
+}

--- a/lib/src/tokens/pragma_typography.dart
+++ b/lib/src/tokens/pragma_typography.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 
+import '../domain/models/model_typography_tokens.dart';
+
 /// Tipografía oficial basada en la familia Poppins y los tamaños
 /// suministrados por el equipo de diseño.
 class PragmaTypography {
@@ -31,6 +33,54 @@ class PragmaTypography {
       labelMedium: style(PragmaTypographyTokens.captionRegular),
       labelSmall: style(PragmaTypographyTokens.footerRegular),
     );
+  }
+
+  static TextTheme textThemeFromTokens({
+    required ModelTypographyTokens typographyTokens,
+    Brightness brightness = Brightness.light,
+  }) {
+    final Color color =
+        brightness == Brightness.dark ? Colors.white : const Color(0xFF111111);
+
+    TextStyle style(ModelTypographyTokenStyle token) =>
+        _styleFromModelToken(token: token, color: color);
+
+    return TextTheme(
+      displayLarge: style(typographyTokens.displayLarge),
+      displayMedium: style(typographyTokens.displayMedium),
+      displaySmall: style(typographyTokens.displaySmall),
+      headlineLarge: style(typographyTokens.headlineLarge),
+      headlineMedium: style(typographyTokens.headlineMedium),
+      headlineSmall: style(typographyTokens.headlineSmall),
+      titleLarge: style(typographyTokens.titleLarge),
+      titleMedium: style(typographyTokens.titleMedium),
+      titleSmall: style(typographyTokens.titleSmall),
+      bodyLarge: style(typographyTokens.bodyLarge),
+      bodyMedium: style(typographyTokens.bodyMedium),
+      bodySmall: style(typographyTokens.bodySmall),
+      labelLarge: style(typographyTokens.labelLarge),
+      labelMedium: style(typographyTokens.labelMedium),
+      labelSmall: style(typographyTokens.labelSmall),
+    );
+  }
+
+  static TextStyle _styleFromModelToken({
+    required ModelTypographyTokenStyle token,
+    required Color color,
+  }) {
+    final TextStyle base = TextStyle(
+      color: color,
+      fontSize: token.fontSize,
+      height: token.lineHeight / token.fontSize,
+      fontWeight: FontWeight.values[token.fontWeight ~/ 100 - 1],
+      letterSpacing: token.letterSpacing,
+    );
+
+    if (GoogleFonts.config.allowRuntimeFetching) {
+      return GoogleFonts.poppins(textStyle: base);
+    }
+
+    return base.copyWith(fontFamily: _fontFamily);
   }
 }
 

--- a/lib/src/widgets/ds_header_widget.dart
+++ b/lib/src/widgets/ds_header_widget.dart
@@ -1,0 +1,214 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+import '../tokens/pragma_border_radius.dart';
+import '../tokens/pragma_spacing.dart';
+
+/// Header del DS con label a la izquierda y acciones libres a la derecha.
+class DsHeaderWidget extends StatelessWidget {
+  const DsHeaderWidget({
+    required this.title,
+    super.key,
+    this.actions = const <Widget>[],
+    this.leading,
+    this.height = 72,
+    this.compactHeight = 64,
+    this.semanticLabel,
+    this.backgroundColor,
+    this.borderColor,
+    this.padding,
+    this.compactBreakpoint = 720,
+  })  : assert(height > 0),
+        assert(compactHeight > 0),
+        assert(compactBreakpoint > 0);
+
+  /// Texto principal renderizado en el extremo izquierdo.
+  final String title;
+
+  /// Lista flexible de acciones para el extremo derecho.
+  final List<Widget> actions;
+
+  /// Slot opcional para branding o contenido previo al título.
+  final Widget? leading;
+
+  /// Altura por defecto para desktop/tablet amplio.
+  final double height;
+
+  /// Altura usada cuando el ancho disponible es compacto.
+  final double compactHeight;
+
+  /// Semántica del contenedor raíz.
+  final String? semanticLabel;
+
+  /// Override de color de fondo.
+  final Color? backgroundColor;
+
+  /// Override del color del borde.
+  final Color? borderColor;
+
+  /// Padding del header. Si se omite, usa tokens adaptativos.
+  final EdgeInsetsGeometry? padding;
+
+  /// Breakpoint para activar modo compacto.
+  final double compactBreakpoint;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme scheme = theme.colorScheme;
+
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        final bool isCompact = constraints.hasBoundedWidth &&
+            constraints.maxWidth < compactBreakpoint;
+
+        final double resolvedHeight = isCompact ? compactHeight : height;
+        final EdgeInsetsGeometry resolvedPadding = padding ??
+            EdgeInsets.symmetric(
+              horizontal: isCompact ? PragmaSpacing.sm : PragmaSpacing.md,
+              vertical: PragmaSpacing.xs,
+            );
+
+        final TextStyle? titleStyle = (isCompact
+                ? theme.textTheme.titleMedium
+                : theme.textTheme.headlineSmall)
+            ?.copyWith(fontWeight: FontWeight.w700);
+
+        final Widget actionsStrip = actions.isEmpty
+            ? const SizedBox.shrink()
+            : IconTheme.merge(
+                data: IconThemeData(size: isCompact ? 20 : 22),
+                child: SingleChildScrollView(
+                  scrollDirection: Axis.horizontal,
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: _withSpacing(
+                      actions,
+                      spacing: isCompact ? PragmaSpacing.xs : PragmaSpacing.sm,
+                    ),
+                  ),
+                ),
+              );
+
+        final Widget leftArea = Row(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            if (leading != null) ...<Widget>[
+              leading!,
+              SizedBox(width: isCompact ? PragmaSpacing.xs : PragmaSpacing.sm),
+            ],
+            Flexible(
+              child: Text(
+                title,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: titleStyle,
+              ),
+            ),
+          ],
+        );
+
+        return Semantics(
+          container: true,
+          label: semanticLabel ?? title,
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              color: backgroundColor ?? scheme.surface,
+              border: Border(
+                bottom: BorderSide(
+                  color: borderColor ?? scheme.outlineVariant,
+                ),
+              ),
+            ),
+            child: ConstrainedBox(
+              constraints: BoxConstraints(minHeight: resolvedHeight),
+              child: Padding(
+                padding: resolvedPadding,
+                child: Row(
+                  children: <Widget>[
+                    Expanded(flex: 5, child: leftArea),
+                    SizedBox(
+                      width: isCompact ? PragmaSpacing.xs : PragmaSpacing.sm,
+                    ),
+                    Flexible(
+                      flex: 4,
+                      child: Align(
+                        alignment: Alignment.centerRight,
+                        child: ConstrainedBox(
+                          constraints: BoxConstraints(
+                            maxWidth: constraints.hasBoundedWidth
+                                ? math.max(
+                                    0,
+                                    constraints.maxWidth *
+                                        (isCompact ? 0.58 : 0.52),
+                                  )
+                                : double.infinity,
+                          ),
+                          child: actionsStrip,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  static List<Widget> _withSpacing(
+    List<Widget> children, {
+    required double spacing,
+  }) {
+    if (children.length <= 1) {
+      return children;
+    }
+
+    final List<Widget> result = <Widget>[];
+    for (int index = 0; index < children.length; index++) {
+      result.add(children[index]);
+      if (index < children.length - 1) {
+        result.add(SizedBox(width: spacing));
+      }
+    }
+    return result;
+  }
+}
+
+/// Wrapper visual para acciones de header cuando se requiere consistencia DS.
+class DsHeaderActionSurface extends StatelessWidget {
+  const DsHeaderActionSurface({
+    required this.child,
+    super.key,
+    this.padding,
+  });
+
+  final Widget child;
+  final EdgeInsetsGeometry? padding;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme scheme = theme.colorScheme;
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: scheme.surfaceContainerLowest,
+        borderRadius:
+            PragmaBorderRadius.circularToken(PragmaBorderRadiusTokens.m),
+        border: Border.all(color: scheme.outlineVariant),
+      ),
+      child: Padding(
+        padding: padding ??
+            const EdgeInsets.symmetric(
+              horizontal: PragmaSpacing.xs,
+              vertical: PragmaSpacing.xxxs,
+            ),
+        child: child,
+      ),
+    );
+  }
+}

--- a/lib/src/widgets/ds_sidebar_menu_widget.dart
+++ b/lib/src/widgets/ds_sidebar_menu_widget.dart
@@ -1,0 +1,410 @@
+import 'package:flutter/material.dart';
+
+import '../domain/models/model_ds_sidebar_menu_item.dart';
+import '../tokens/pragma_border_radius.dart';
+import '../tokens/pragma_spacing.dart';
+import 'pragma_logo_widget.dart';
+import 'pragma_tooltip_widget.dart';
+
+/// Sidebar de navegacion del DS para apps Flutter/Web.
+class DsSidebarMenuWidget extends StatelessWidget {
+  const DsSidebarMenuWidget({
+    required this.items,
+    super.key,
+    this.activeId,
+    this.collapsed = false,
+    this.onItemTap,
+    this.onCollapsedToggle,
+    this.title,
+    this.header,
+    this.footer,
+    this.width = 224,
+    this.collapsedWidth = 72,
+    this.showCollapseToggle = false,
+    this.semanticLabel = 'Sidebar menu',
+    this.backgroundColor,
+  })  : assert(width > 0),
+        assert(collapsedWidth > 0),
+        assert(items.length > 0, 'Declara al menos un item para el sidebar.');
+
+  /// Items renderizados en la seccion principal.
+  final List<ModelDsSidebarMenuItem> items;
+
+  /// Item activo actual.
+  final String? activeId;
+
+  /// Modo visual colapsado o expandido.
+  final bool collapsed;
+
+  /// Callback al presionar un item habilitado.
+  final ValueChanged<String>? onItemTap;
+
+  /// Callback para alternar `collapsed` cuando se usa el toggle interno.
+  final ValueChanged<bool>? onCollapsedToggle;
+
+  /// Titulo textual opcional para el bloque superior.
+  final String? title;
+
+  /// Slot opcional para contenido custom en la cabecera.
+  final Widget? header;
+
+  /// Slot opcional para contenido custom en el pie.
+  final Widget? footer;
+
+  /// Ancho cuando esta expandido.
+  final double width;
+
+  /// Ancho cuando esta colapsado.
+  final double collapsedWidth;
+
+  /// Muestra el control de colapsar/expandir.
+  final bool showCollapseToggle;
+
+  /// Etiqueta de accesibilidad del contenedor completo.
+  final String semanticLabel;
+
+  /// Override opcional del color de fondo.
+  final Color? backgroundColor;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme scheme = theme.colorScheme;
+    final double resolvedWidth = collapsed ? collapsedWidth : width;
+
+    return Semantics(
+      container: true,
+      label: semanticLabel,
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 220),
+        curve: Curves.easeOut,
+        width: resolvedWidth,
+        decoration: BoxDecoration(
+          color: backgroundColor ?? scheme.primary,
+          borderRadius: BorderRadius.zero,
+          border: Border.all(
+            color: scheme.primaryContainer.withValues(alpha: 0.55),
+          ),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(PragmaSpacing.sm),
+          child: LayoutBuilder(
+            builder: (BuildContext context, BoxConstraints constraints) {
+              final Widget itemsList = ListView.separated(
+                padding: EdgeInsets.zero,
+                shrinkWrap: !constraints.hasBoundedHeight,
+                physics: constraints.hasBoundedHeight
+                    ? null
+                    : const NeverScrollableScrollPhysics(),
+                itemCount: items.length,
+                separatorBuilder: (_, __) =>
+                    const SizedBox(height: PragmaSpacing.xs),
+                itemBuilder: (BuildContext context, int index) {
+                  final ModelDsSidebarMenuItem item = items[index];
+                  return _SidebarMenuTile(
+                    item: item,
+                    collapsed: collapsed,
+                    active: activeId == item.id,
+                    onTap: item.enabled ? () => onItemTap?.call(item.id) : null,
+                  );
+                },
+              );
+
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: <Widget>[
+                  _SidebarHeader(
+                    collapsed: collapsed,
+                    title: title,
+                    header: header,
+                    onCollapsedToggle:
+                        showCollapseToggle ? onCollapsedToggle : null,
+                  ),
+                  const SizedBox(height: PragmaSpacing.md),
+                  if (constraints.hasBoundedHeight)
+                    Expanded(child: itemsList)
+                  else
+                    itemsList,
+                  if (footer != null) ...<Widget>[
+                    const SizedBox(height: PragmaSpacing.md),
+                    Divider(
+                      height: 1,
+                      thickness: 1,
+                      color: scheme.onPrimary.withValues(alpha: 0.24),
+                    ),
+                    const SizedBox(height: PragmaSpacing.sm),
+                    footer!,
+                  ],
+                ],
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SidebarHeader extends StatelessWidget {
+  const _SidebarHeader({
+    required this.collapsed,
+    this.title,
+    this.header,
+    this.onCollapsedToggle,
+  });
+
+  final bool collapsed;
+  final String? title;
+  final Widget? header;
+  final ValueChanged<bool>? onCollapsedToggle;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme scheme = theme.colorScheme;
+    const Widget brandIsotype = _SidebarBrandIsotype();
+
+    final Widget defaultHeader;
+    if (collapsed) {
+      defaultHeader = title == null
+          ? brandIsotype
+          : PragmaTooltipWidget(
+              message: title!,
+              placement: PragmaTooltipPlacement.right,
+              child: brandIsotype,
+            );
+    } else {
+      defaultHeader = Row(
+        children: <Widget>[
+          brandIsotype,
+          const SizedBox(width: PragmaSpacing.xs),
+          Container(
+            width: 1,
+            height: 18,
+            color: scheme.onPrimary.withValues(alpha: 0.45),
+          ),
+          const SizedBox(width: PragmaSpacing.xs),
+          Expanded(
+            child: title == null
+                ? const SizedBox.shrink()
+                : Text(
+                    title!,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      color: scheme.onPrimary,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+          ),
+        ],
+      );
+    }
+
+    return Row(
+      children: <Widget>[
+        Expanded(
+          child: header ?? defaultHeader,
+        ),
+        if (onCollapsedToggle != null)
+          IconButton(
+            tooltip: collapsed ? 'Expandir menu' : 'Colapsar menu',
+            onPressed: () => onCollapsedToggle!.call(!collapsed),
+            visualDensity: VisualDensity.compact,
+            icon: Icon(
+              collapsed ? Icons.chevron_right : Icons.chevron_left,
+              color: scheme.onPrimary,
+              size: 20,
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _SidebarBrandIsotype extends StatelessWidget {
+  const _SidebarBrandIsotype();
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData baseTheme = Theme.of(context);
+    return SizedBox(
+      width: 28,
+      height: 28,
+      child: Theme(
+        data: baseTheme.copyWith(brightness: Brightness.dark),
+        child: const PragmaLogoWidget(
+          width: 28,
+          variant: PragmaLogoVariant.isotypeCircle,
+          margin: EdgeInsets.zero,
+          alignment: Alignment.center,
+          semanticLabel: 'Pragma imagotipo',
+        ),
+      ),
+    );
+  }
+}
+
+class _SidebarMenuTile extends StatelessWidget {
+  const _SidebarMenuTile({
+    required this.item,
+    required this.collapsed,
+    required this.active,
+    required this.onTap,
+  });
+
+  final ModelDsSidebarMenuItem item;
+  final bool collapsed;
+  final bool active;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme scheme = theme.colorScheme;
+    final bool enabled = onTap != null;
+
+    final Color foreground = enabled
+        ? (active ? scheme.onPrimary : scheme.onPrimary.withValues(alpha: 0.88))
+        : scheme.onPrimary.withValues(alpha: 0.45);
+
+    final Color baseBackground = active
+        ? scheme.primaryContainer.withValues(alpha: 0.35)
+        : Colors.transparent;
+
+    final BorderRadius borderRadius = PragmaBorderRadius.circularToken(
+      PragmaBorderRadiusTokens.m,
+    );
+
+    Widget tile = LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        final bool compactMode = collapsed || constraints.maxWidth < 112;
+
+        return Semantics(
+          button: true,
+          selected: active,
+          enabled: enabled,
+          label: item.semanticLabel ?? item.label,
+          onTap: onTap,
+          child: ExcludeSemantics(
+            child: TextButton(
+              onPressed: onTap,
+              style: ButtonStyle(
+                alignment:
+                    compactMode ? Alignment.center : Alignment.centerLeft,
+                padding: WidgetStatePropertyAll<EdgeInsetsGeometry>(
+                  EdgeInsets.symmetric(
+                    horizontal:
+                        compactMode ? PragmaSpacing.xs : PragmaSpacing.sm,
+                    vertical: PragmaSpacing.xs,
+                  ),
+                ),
+                shape: WidgetStatePropertyAll<OutlinedBorder>(
+                  RoundedRectangleBorder(borderRadius: borderRadius),
+                ),
+                minimumSize: const WidgetStatePropertyAll<Size>(Size.zero),
+                tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                backgroundColor: WidgetStateProperty.resolveWith<Color>(
+                  (Set<WidgetState> states) {
+                    if (states.contains(WidgetState.pressed)) {
+                      return scheme.primaryContainer.withValues(alpha: 0.4);
+                    }
+                    if (states.contains(WidgetState.hovered) ||
+                        states.contains(WidgetState.focused)) {
+                      return scheme.primaryContainer.withValues(alpha: 0.28);
+                    }
+                    return baseBackground;
+                  },
+                ),
+                foregroundColor: WidgetStatePropertyAll<Color>(foreground),
+                overlayColor: WidgetStatePropertyAll<Color>(
+                  scheme.onPrimary.withValues(alpha: 0.06),
+                ),
+                side: WidgetStateProperty.resolveWith<BorderSide?>(
+                  (Set<WidgetState> states) {
+                    if (states.contains(WidgetState.focused)) {
+                      return BorderSide(
+                        color: scheme.onPrimary.withValues(alpha: 0.85),
+                        width: 1.6,
+                      );
+                    }
+                    if (active) {
+                      return BorderSide(
+                        color: scheme.onPrimary.withValues(alpha: 0.2),
+                        width: 1.2,
+                      );
+                    }
+                    return const BorderSide(
+                      color: Colors.transparent,
+                      width: 1.2,
+                    );
+                  },
+                ),
+              ),
+              child: Row(
+                mainAxisAlignment: compactMode
+                    ? MainAxisAlignment.center
+                    : MainAxisAlignment.start,
+                children: <Widget>[
+                  Icon(
+                    _SidebarIconResolver.resolve(item.iconToken),
+                    size: 20,
+                  ),
+                  if (!compactMode) ...<Widget>[
+                    const SizedBox(width: PragmaSpacing.xs),
+                    Expanded(
+                      child: Text(
+                        item.label,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: theme.textTheme.labelLarge?.copyWith(
+                          fontWeight:
+                              active ? FontWeight.w700 : FontWeight.w500,
+                        ),
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+
+    if (collapsed) {
+      tile = PragmaTooltipWidget(
+        message: item.label,
+        placement: PragmaTooltipPlacement.right,
+        child: tile,
+      );
+    }
+
+    return tile;
+  }
+}
+
+class _SidebarIconResolver {
+  const _SidebarIconResolver._();
+
+  static IconData resolve(DsSidebarIconToken token) {
+    switch (token) {
+      case DsSidebarIconToken.dashboard:
+        return Icons.space_dashboard_outlined;
+      case DsSidebarIconToken.projects:
+        return Icons.folder_open_outlined;
+      case DsSidebarIconToken.reports:
+        return Icons.analytics_outlined;
+      case DsSidebarIconToken.settings:
+        return Icons.settings_outlined;
+      case DsSidebarIconToken.back:
+        return Icons.arrow_back;
+      case DsSidebarIconToken.home:
+        return Icons.home_outlined;
+      case DsSidebarIconToken.analytics:
+        return Icons.insights_outlined;
+      case DsSidebarIconToken.lock:
+        return Icons.lock_outline;
+    }
+  }
+}

--- a/lib/src/widgets/ds_sidebar_menu_widget.dart
+++ b/lib/src/widgets/ds_sidebar_menu_widget.dart
@@ -160,64 +160,69 @@ class _SidebarHeader extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final ThemeData theme = Theme.of(context);
-    final ColorScheme scheme = theme.colorScheme;
-    const Widget brandIsotype = _SidebarBrandIsotype();
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        final ThemeData theme = Theme.of(context);
+        final ColorScheme scheme = theme.colorScheme;
+        const Widget brandIsotype = _SidebarBrandIsotype();
+        final bool compactHeader = collapsed || constraints.maxWidth < 92;
 
-    final Widget defaultHeader;
-    if (collapsed) {
-      defaultHeader = title == null
-          ? brandIsotype
-          : PragmaTooltipWidget(
-              message: title!,
-              placement: PragmaTooltipPlacement.right,
-              child: brandIsotype,
-            );
-    } else {
-      defaultHeader = Row(
-        children: <Widget>[
-          brandIsotype,
-          const SizedBox(width: PragmaSpacing.xs),
-          Container(
-            width: 1,
-            height: 18,
-            color: scheme.onPrimary.withValues(alpha: 0.45),
-          ),
-          const SizedBox(width: PragmaSpacing.xs),
-          Expanded(
-            child: title == null
-                ? const SizedBox.shrink()
-                : Text(
-                    title!,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: theme.textTheme.titleMedium?.copyWith(
-                      color: scheme.onPrimary,
-                      fontWeight: FontWeight.w700,
-                    ),
-                  ),
-          ),
-        ],
-      );
-    }
+        final Widget defaultHeader;
+        if (compactHeader) {
+          defaultHeader = title == null
+              ? brandIsotype
+              : PragmaTooltipWidget(
+                  message: title!,
+                  placement: PragmaTooltipPlacement.right,
+                  child: brandIsotype,
+                );
+        } else {
+          defaultHeader = Row(
+            children: <Widget>[
+              brandIsotype,
+              const SizedBox(width: PragmaSpacing.xs),
+              Container(
+                width: 1,
+                height: 18,
+                color: scheme.onPrimary.withValues(alpha: 0.45),
+              ),
+              const SizedBox(width: PragmaSpacing.xs),
+              Expanded(
+                child: title == null
+                    ? const SizedBox.shrink()
+                    : Text(
+                        title!,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: theme.textTheme.titleMedium?.copyWith(
+                          color: scheme.onPrimary,
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+              ),
+            ],
+          );
+        }
 
-    return Row(
-      children: <Widget>[
-        Expanded(
-          child: header ?? defaultHeader,
-        ),
-        if (onCollapsedToggle != null)
-          IconButton(
-            tooltip: collapsed ? 'Expandir menu' : 'Colapsar menu',
-            onPressed: () => onCollapsedToggle!.call(!collapsed),
-            visualDensity: VisualDensity.compact,
-            icon: Icon(
-              collapsed ? Icons.chevron_right : Icons.chevron_left,
-              color: scheme.onPrimary,
-              size: 20,
+        return Row(
+          children: <Widget>[
+            Expanded(
+              child: header ?? defaultHeader,
             ),
-          ),
-      ],
+            if (onCollapsedToggle != null)
+              IconButton(
+                tooltip: collapsed ? 'Expandir menu' : 'Colapsar menu',
+                onPressed: () => onCollapsedToggle!.call(!collapsed),
+                visualDensity: VisualDensity.compact,
+                icon: Icon(
+                  collapsed ? Icons.chevron_right : Icons.chevron_left,
+                  color: scheme.onPrimary,
+                  size: 20,
+                ),
+              ),
+          ],
+        );
+      },
     );
   }
 }
@@ -358,6 +363,7 @@ class _SidebarMenuTile extends StatelessWidget {
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
                         style: theme.textTheme.labelLarge?.copyWith(
+                          color: foreground,
                           fontWeight:
                               active ? FontWeight.w700 : FontWeight.w500,
                         ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: pragma_design_system
 description: >-
   Flutter library that gathers Pragma's design tokens, themes, and base components for mobile apps.
-version: 1.4.0
+version: 1.5.0
 homepage: https://pragma.co/
 repository: https://github.com/somospragma/movil-tecnicas-desarrollo-lib-dart-pragma-design-system
 issue_tracker: https://github.com/somospragma/movil-tecnicas-desarrollo-lib-dart-pragma-design-system/issues

--- a/test/ds_header_widget_test.dart
+++ b/test/ds_header_widget_test.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pragma_design_system/pragma_design_system.dart';
+
+void main() {
+  Widget buildHeader({double? width, List<Widget> actions = const <Widget>[]}) {
+    final Widget child = MaterialApp(
+      theme: PragmaTheme.light(),
+      home: Scaffold(
+        body: DsHeaderWidget(
+          title: 'Panel principal',
+          actions: actions,
+        ),
+      ),
+    );
+
+    if (width == null) {
+      return child;
+    }
+
+    return MaterialApp(
+      theme: PragmaTheme.light(),
+      home: Scaffold(
+        body: SizedBox(
+          width: width,
+          child: DsHeaderWidget(
+            title: 'Panel principal',
+            actions: actions,
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('renders title and actions', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      buildHeader(
+        actions: <Widget>[
+          IconButton(
+            onPressed: () {},
+            tooltip: 'Buscar',
+            icon: const Icon(Icons.search),
+          ),
+          const CircleAvatar(child: Text('PD')),
+        ],
+      ),
+    );
+
+    expect(find.text('Panel principal'), findsOneWidget);
+    expect(find.byTooltip('Buscar'), findsOneWidget);
+    expect(find.text('PD'), findsOneWidget);
+  });
+
+  testWidgets('does not overflow on narrow width', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      buildHeader(
+        width: 320,
+        actions: <Widget>[
+          IconButton(
+            onPressed: () {},
+            tooltip: 'Buscar',
+            icon: const Icon(Icons.search),
+          ),
+          IconButton(
+            onPressed: () {},
+            tooltip: 'Alertas',
+            icon: const Icon(Icons.notifications_outlined),
+          ),
+          const CircleAvatar(child: Text('PD')),
+        ],
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('allows interaction with action widgets',
+      (WidgetTester tester) async {
+    bool tapped = false;
+
+    await tester.pumpWidget(
+      buildHeader(
+        actions: <Widget>[
+          IconButton(
+            onPressed: () => tapped = true,
+            tooltip: 'Buscar',
+            icon: const Icon(Icons.search),
+          ),
+        ],
+      ),
+    );
+
+    await tester.tap(find.byTooltip('Buscar'));
+    await tester.pumpAndSettle();
+
+    expect(tapped, isTrue);
+  });
+}

--- a/test/ds_sidebar_menu_widget_test.dart
+++ b/test/ds_sidebar_menu_widget_test.dart
@@ -1,0 +1,177 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pragma_design_system/pragma_design_system.dart';
+
+void main() {
+  final List<ModelDsSidebarMenuItem> items = <ModelDsSidebarMenuItem>[
+    ModelDsSidebarMenuItem(
+      id: 'home',
+      label: 'Inicio',
+      iconToken: DsSidebarIconToken.home,
+    ),
+    ModelDsSidebarMenuItem(
+      id: 'analytics',
+      label: 'Analitica',
+      iconToken: DsSidebarIconToken.analytics,
+    ),
+    ModelDsSidebarMenuItem(
+      id: 'disabled',
+      label: 'Bloqueado',
+      iconToken: DsSidebarIconToken.lock,
+      enabled: false,
+    ),
+  ];
+
+  Widget buildSidebar({
+    bool collapsed = false,
+    String? activeId,
+    ValueChanged<String>? onItemTap,
+    ValueChanged<bool>? onCollapsedToggle,
+    bool showCollapseToggle = false,
+  }) {
+    return MaterialApp(
+      theme: PragmaTheme.light(),
+      home: Scaffold(
+        body: DsSidebarMenuWidget(
+          items: items,
+          title: 'Menu',
+          collapsed: collapsed,
+          activeId: activeId,
+          onItemTap: onItemTap,
+          onCollapsedToggle: onCollapsedToggle,
+          showCollapseToggle: showCollapseToggle,
+        ),
+      ),
+    );
+  }
+
+  testWidgets('renders labels in expanded mode', (WidgetTester tester) async {
+    await tester.pumpWidget(buildSidebar());
+
+    expect(find.text('Inicio'), findsOneWidget);
+    expect(find.text('Analitica'), findsOneWidget);
+  });
+
+  testWidgets('hides labels and enables tooltip wrappers in collapsed mode',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(buildSidebar(collapsed: true));
+
+    expect(find.text('Inicio'), findsNothing);
+    expect(find.byType(PragmaTooltipWidget), findsNWidgets(4));
+  });
+
+  testWidgets('emits onItemTap with item id when enabled',
+      (WidgetTester tester) async {
+    String? selectedId;
+    await tester.pumpWidget(
+      buildSidebar(
+        onItemTap: (String id) => selectedId = id,
+      ),
+    );
+
+    await tester.tap(find.text('Analitica'));
+    await tester.pumpAndSettle();
+
+    expect(selectedId, 'analytics');
+  });
+
+  testWidgets('disabled items ignore interaction', (WidgetTester tester) async {
+    String? selectedId;
+    await tester.pumpWidget(
+      buildSidebar(
+        onItemTap: (String id) => selectedId = id,
+      ),
+    );
+
+    await tester.tap(find.text('Bloqueado'));
+    await tester.pumpAndSettle();
+
+    expect(selectedId, isNull);
+  });
+
+  testWidgets('collapse toggle emits the inverse state',
+      (WidgetTester tester) async {
+    bool? next;
+    await tester.pumpWidget(
+      buildSidebar(
+        onCollapsedToggle: (bool value) => next = value,
+        showCollapseToggle: true,
+      ),
+    );
+
+    await tester.tap(find.byTooltip('Colapsar menu'));
+    await tester.pumpAndSettle();
+
+    expect(next, isTrue);
+  });
+
+  testWidgets('marks active item as selected in semantics',
+      (WidgetTester tester) async {
+    final SemanticsHandle semantics = tester.ensureSemantics();
+    await tester.pumpWidget(
+      buildSidebar(activeId: 'analytics'),
+    );
+
+    expect(
+      tester.getSemantics(find.text('Analitica')),
+      matchesSemantics(
+        label: 'Analitica',
+        isButton: true,
+        isEnabled: true,
+        hasEnabledState: true,
+        isSelected: true,
+        hasSelectedState: true,
+        hasTapAction: true,
+      ),
+    );
+    semantics.dispose();
+  });
+
+  testWidgets('keeps collapse toggle hidden by default',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(buildSidebar());
+
+    expect(find.byTooltip('Colapsar menu'), findsNothing);
+    expect(find.byTooltip('Expandir menu'), findsNothing);
+  });
+
+  testWidgets('renders safely inside vertical scrollables',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: PragmaTheme.light(),
+        home: Scaffold(
+          body: ListView(
+            children: <Widget>[
+              DsSidebarMenuWidget(
+                items: items,
+                title: 'Menu',
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Inicio'), findsOneWidget);
+  });
+
+  testWidgets('does not overflow when expanded width is narrow',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: PragmaTheme.light(),
+        home: Scaffold(
+          body: DsSidebarMenuWidget(
+            items: items,
+            title: 'Menu',
+            width: 92,
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/test/model_design_system_domain_test.dart
+++ b/test/model_design_system_domain_test.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:pragma_design_system/pragma_design_system.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  GoogleFonts.config.allowRuntimeFetching = false;
+
+  group('ModelThemeData', () {
+    test('pragmaDefault uses Pragma color schemes', () {
+      final ModelThemeData model = ModelThemeData.pragmaDefault();
+
+      expect(model.useMaterial3, isTrue);
+      expect(model.lightScheme.primary, PragmaColors.lightScheme.primary);
+      expect(model.darkScheme.primary, PragmaColors.darkScheme.primary);
+    });
+
+    test('json roundtrip keeps values', () {
+      final ModelThemeData model = ModelThemeData.pragmaDefault();
+
+      final ModelThemeData restored = ModelThemeData.fromJson(model.toJson());
+
+      expect(restored.toJson(), model.toJson());
+    });
+  });
+
+  group('ModelSemanticColors', () {
+    test('fallback json roundtrip works', () {
+      final ModelSemanticColors model = ModelSemanticColors.fallbackLight();
+
+      final ModelSemanticColors restored =
+          ModelSemanticColors.fromJson(model.toJson());
+
+      expect(restored, model);
+    });
+  });
+
+  group('ModelDsComponentAnatomy', () {
+    test('json roundtrip works', () {
+      const ModelDsComponentAnatomy model = ModelDsComponentAnatomy(
+        id: 'ds.sidebar',
+        name: 'Sidebar',
+        description: 'Main app navigation component.',
+        tags: <String>['navigation', 'layout'],
+        status: ModelDsComponentStatusEnum.stable,
+        platforms: <ModelDsComponentPlatformEnum>[
+          ModelDsComponentPlatformEnum.web,
+          ModelDsComponentPlatformEnum.android,
+        ],
+        slots: <ModelDsComponentSlot>[
+          ModelDsComponentSlot(
+            name: 'Header',
+            role: 'Brand and context label',
+            rules: <String>['Shows imagotype in collapsed mode'],
+            tokensUsed: <String>['spacingSm', 'primaryPurple500'],
+          ),
+        ],
+      );
+
+      final ModelDsComponentAnatomy restored =
+          ModelDsComponentAnatomy.fromJson(model.toJson());
+
+      expect(restored.id, model.id);
+      expect(restored.name, model.name);
+      expect(restored.status, model.status);
+      expect(restored.slots, model.slots);
+    });
+  });
+
+  group('ModelDesignSystem', () {
+    test('pragmaDefault is serializable and builds theme', () {
+      final ModelDesignSystem ds = ModelDesignSystem.pragmaDefault();
+      final ModelDesignSystem restored =
+          ModelDesignSystem.fromJson(ds.toJson());
+
+      final ThemeData light =
+          restored.toThemeData(brightness: Brightness.light);
+
+      expect(restored.toJson(), ds.toJson());
+      expect(light.extension<DsExtendedTokensExtension>(), isNotNull);
+      expect(light.dsTokens.spacing, ds.tokens.spacing);
+      expect(light.dsSemantic.success, ds.semanticLight.success);
+      expect(
+        light.textTheme.bodyMedium?.fontSize,
+        ds.typographyTokens.bodyMedium.fontSize,
+      );
+    });
+
+    test('typographyTokens override text theme generation', () {
+      final ModelDesignSystem base = ModelDesignSystem.pragmaDefault();
+      final ModelDesignSystem tuned = base.copyWith(
+        typographyTokens: base.typographyTokens.copyWith(
+          bodyMedium: base.typographyTokens.bodyMedium.copyWith(fontSize: 18),
+        ),
+      );
+
+      final ThemeData light = tuned.toThemeData(brightness: Brightness.light);
+
+      expect(light.textTheme.bodyMedium?.fontSize, 18);
+    });
+  });
+
+  group('ModelTypographyTokens', () {
+    test('json roundtrip works', () {
+      final ModelTypographyTokens model = ModelTypographyTokens.pragmaDefault();
+      final ModelTypographyTokens restored =
+          ModelTypographyTokens.fromJson(model.toJson());
+
+      expect(restored, model);
+    });
+  });
+}

--- a/test/model_ds_dataviz_palette_test.dart
+++ b/test/model_ds_dataviz_palette_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pragma_design_system/pragma_design_system.dart';
+
+void main() {
+  test('fallback uses available DS foundation tokens', () {
+    final ModelDataVizPalette palette = ModelDataVizPalette.fallback();
+
+    expect(palette.categorical.length, 10);
+    expect(palette.sequential.length, 6);
+    expect(palette.categorical.first, PragmaColorTokens.primaryPurple500);
+    expect(palette.sequential.first, PragmaColorTokens.primaryPurple50);
+    expect(palette.sequential.last, PragmaColorTokens.primaryPurple900);
+  });
+
+  test('roundtrip preserves categorical and sequential colors', () {
+    final ModelDataVizPalette original = ModelDataVizPalette.fallback();
+
+    final Map<String, dynamic> json = original.toJson();
+    final ModelDataVizPalette decoded = ModelDataVizPalette.fromJson(json);
+
+    expect(decoded, equals(original));
+  });
+
+  test('sequentialAt interpolates and clamps values', () {
+    const ModelDataVizPalette palette = ModelDataVizPalette(
+      categorical: <Color>[Color(0xFF000000)],
+      sequential: <Color>[Color(0xFF000000), Color(0xFFFFFFFF)],
+    );
+
+    expect(palette.sequentialAt(-1), const Color(0xFF000000));
+    expect(palette.sequentialAt(2), const Color(0xFFFFFFFF));
+    final int midpoint = palette.sequentialAt(0.5).toARGB32();
+    expect(midpoint, anyOf(0xFF7F7F7F, 0xFF808080));
+  });
+}

--- a/test/model_ds_sidebar_menu_item_test.dart
+++ b/test/model_ds_sidebar_menu_item_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pragma_design_system/pragma_design_system.dart';
+
+void main() {
+  test('roundtrip keeps sidebar item fields intact', () {
+    final ModelDsSidebarMenuItem original = ModelDsSidebarMenuItem(
+      id: 'reports',
+      label: 'Reportes',
+      iconToken: DsSidebarIconToken.reports,
+      enabled: false,
+      semanticLabel: 'Abrir reportes',
+    );
+
+    final ModelDsSidebarMenuItem decoded =
+        ModelDsSidebarMenuItem.fromJson(original.toJson());
+
+    expect(decoded, equals(original));
+    expect(decoded.iconToken, DsSidebarIconToken.reports);
+  });
+
+  test('fromJson handles unknown icon token using fallback', () {
+    final ModelDsSidebarMenuItem decoded = ModelDsSidebarMenuItem.fromJson(
+      const <String, dynamic>{
+        'id': 'x',
+        'label': 'Elemento',
+        'iconToken': 'not-allowed',
+      },
+    );
+
+    expect(decoded.iconToken, DsSidebarIconToken.home);
+    expect(decoded.enabled, isTrue);
+  });
+
+  test('copyWith overrides selected fields', () {
+    final ModelDsSidebarMenuItem source = ModelDsSidebarMenuItem(
+      id: 'home',
+      label: 'Inicio',
+      iconToken: DsSidebarIconToken.home,
+    );
+
+    final ModelDsSidebarMenuItem updated = source.copyWith(
+      id: 'settings',
+      iconToken: DsSidebarIconToken.settings,
+      enabled: false,
+    );
+
+    expect(updated.id, 'settings');
+    expect(updated.iconToken, DsSidebarIconToken.settings);
+    expect(updated.enabled, isFalse);
+    expect(updated.label, 'Inicio');
+  });
+}


### PR DESCRIPTION
## [1.5.0] - 2026-02-16

### Added

- `DsHeaderWidget`, header base con label a la izquierda y área de acciones flexibles a la derecha, con comportamiento responsivo para anchos compactos.
- `DsSidebarMenuWidget`, sidebar navegable con estados `expanded/collapsed`, item activo, disabled, tooltip en modo colapsado, slots de header/footer y callback para toggle.
- Test suite dedicada para `DsSidebarMenuWidget` cubriendo render, interacción, semántica de selección y toggle.
- Showcase interactivo del sidebar en `example/lib/main.dart` y snippet de uso en el README.
- Modelos de dominio DS adaptados a Pragma y exportados públicamente: `ModelThemeData`, `ModelSemanticColors`, `ModelDataVizPalette`, `ModelDsComponentAnatomy`, `ModelDesignSystem` y `ModelTypographyTokens`.
- Integración de `ModelTypographyTokens` con `PragmaTypography` para construir `TextTheme` desde tokens (`textThemeFromTokens`).
- Extensiones de tema para consumir DS desde `ThemeData`: `DsExtendedTokensExtension`, `DsSemanticColorsExtension` y `DsDataVizPaletteExtension`.
- Pruebas de roundtrip/serialización y construcción de tema para el agregado `ModelDesignSystem` y los nuevos modelos de dominio.
- Documentación nueva para DS: `doc/ds_sidebar.md`, `doc/ds_header.md`, `doc/ds_models.md` y `doc/model_ds_sidebar_menu_item.md`.